### PR TITLE
config: unify FusedModelConfig + LoRAAdapterConfig into ModelConfig, …

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -64,25 +64,47 @@ class LLMConfig:
 
 
 @dataclass
-class FusedModelConfig:
-    """Configuration for a fused (LoRA merged into base) model.
+class ModelConfig:
+    """Unified configuration for a generation model (LoRA adapter OR fused model).
 
-    These settings apply when using a standalone model without an adapter.
+    Both kinds of entries share almost every field. LoRA-specific options
+    (scale, backend, quantization, hf_adapter_path) sit at defaults for fused
+    usage. `author` is only meaningful for fused entries.
     """
 
     enabled: bool = True
-    author: str = ""
+
+    # Sampling
     temperature: float = 0.6
     top_p: float = 0.92
     min_p: float = 0.05
     repetition_penalty: float = 1.15
     max_tokens: int = 512
+
+    # Persona / output shaping
     worldview: str = ""
     fiction_markers: List[str] = field(default_factory=list)
     expand_for_texture: Optional[bool] = None
     perspective: Optional[str] = None
     verify_entailment: Optional[bool] = None
     merge_paragraphs: Optional[int] = None
+
+    # LoRA-only
+    scale: float = 1.0
+    checkpoint: Optional[str] = None
+    backend: str = "auto"
+    device: str = "auto"
+    load_in_4bit: bool = True
+    load_in_8bit: bool = False
+    hf_adapter_path: Optional[str] = None
+
+    # Fused-only
+    author: str = ""
+
+
+# Backwards-compat aliases — both old names resolve to the unified class.
+LoRAAdapterConfig = ModelConfig
+FusedModelConfig = ModelConfig
 
 
 @dataclass
@@ -102,10 +124,10 @@ class GenerationConfig:
     use_adapter: bool = True
 
     # Fused model settings (path -> config mapping)
-    models: Dict[str, "FusedModelConfig"] = field(default_factory=dict)
+    models: Dict[str, "ModelConfig"] = field(default_factory=dict)
 
     # LoRA adapter settings (path -> config mapping)
-    lora_adapters: Dict[str, "LoRAAdapterConfig"] = field(default_factory=dict)
+    lora_adapters: Dict[str, "ModelConfig"] = field(default_factory=dict)
 
     # Neutralization settings
     skip_neutralization: bool = (
@@ -129,48 +151,6 @@ class GenerationConfig:
     use_persona: bool = True  # Enable persona-based prompting
     apply_input_perturbation: bool = (
         True  # Apply 8% noise to match training distribution
-    )
-
-
-@dataclass
-class LoRAAdapterConfig:
-    """Configuration for a specific LoRA adapter.
-
-    These settings control the balance between style strength and coherence.
-    Each adapter in lora_adapters can have its own settings.
-    """
-
-    enabled: bool = True  # Whether this adapter is active
-    scale: float = 1.0  # Adapter influence (0.0=base only, 1.0=full, >1.0=amplified)
-    temperature: float = 0.6  # Higher = more creative, lower = more coherent
-    top_p: float = 0.92  # Nucleus sampling threshold
-    min_p: float = 0.05  # Minimum probability filter
-    repetition_penalty: float = 1.15  # Penalty for repeating tokens
-    max_tokens: int = 512  # Maximum tokens to generate
-    worldview: str = ""  # Author worldview prompt file
-    fiction_markers: List[str] = field(
-        default_factory=list
-    )  # Fiction markers to filter from output
-    checkpoint: Optional[str] = None  # Specific checkpoint to use
-    # Backend configuration
-    backend: str = "auto"  # "auto", "mlx", or "pytorch"
-    device: str = "auto"  # Device for PyTorch: "auto", "cuda", "cpu", "mps"
-    load_in_4bit: bool = True  # Use 4-bit quantization (PyTorch with CUDA only)
-    load_in_8bit: bool = False  # Use 8-bit quantization (PyTorch with CUDA only)
-    hf_adapter_path: Optional[str] = (
-        None  # HuggingFace adapter path (if different from local)
-    )
-    expand_for_texture: Optional[bool] = (
-        None  # Per-adapter override for texture expansion (None = use global)
-    )
-    perspective: Optional[str] = (
-        None  # Per-adapter perspective override (None = use global)
-    )
-    verify_entailment: Optional[bool] = (
-        None  # Per-adapter verification override (None = use global/CLI)
-    )
-    merge_paragraphs: Optional[int] = (
-        None  # Merge short paragraphs to reach this minimum word count before LoRA
     )
 
 
@@ -250,7 +230,7 @@ def _parse_llm_provider_config(data: Dict) -> LLMProviderConfig:
     )
 
 
-_KNOWN_ADAPTER_FIELDS = {
+_KNOWN_MODEL_FIELDS = {
     "enabled",
     "scale",
     "temperature",
@@ -270,21 +250,26 @@ _KNOWN_ADAPTER_FIELDS = {
     "perspective",
     "verify_entailment",
     "merge_paragraphs",
+    "author",
 }
 
 
-def _parse_lora_adapter_config(data: Dict) -> LoRAAdapterConfig:
-    """Parse LoRA adapter configuration from dict."""
+def _parse_model_config(data: Dict) -> ModelConfig:
+    """Parse a model/adapter configuration dict into ModelConfig.
+
+    Handles entries from both `generation.models` (fused) and
+    `generation.lora_adapters` — the shape is identical modulo defaults.
+    """
     unknown_fields = {
         k for k in data.keys()
-        if k not in _KNOWN_ADAPTER_FIELDS and not k.startswith("_")
+        if k not in _KNOWN_MODEL_FIELDS and not k.startswith("_")
     }
     if unknown_fields:
         logger.warning(
-            f"Unknown adapter config fields (ignored): {', '.join(sorted(unknown_fields))}"
+            f"Unknown model config fields (ignored): {', '.join(sorted(unknown_fields))}"
         )
 
-    return LoRAAdapterConfig(
+    return ModelConfig(
         enabled=data.get("enabled", True),
         scale=data.get("scale", 1.0),
         temperature=data.get("temperature", 0.6),
@@ -295,7 +280,6 @@ def _parse_lora_adapter_config(data: Dict) -> LoRAAdapterConfig:
         worldview=data.get("worldview", ""),
         fiction_markers=data.get("fiction_markers", []),
         checkpoint=data.get("checkpoint"),
-        # Backend configuration
         backend=data.get("backend", "auto"),
         device=data.get("device", "auto"),
         load_in_4bit=data.get("load_in_4bit", True),
@@ -305,75 +289,31 @@ def _parse_lora_adapter_config(data: Dict) -> LoRAAdapterConfig:
         perspective=data.get("perspective"),
         verify_entailment=data.get("verify_entailment"),
         merge_paragraphs=data.get("merge_paragraphs"),
-    )
-
-
-_KNOWN_MODEL_FIELDS = {
-    "enabled",
-    "author",
-    "temperature",
-    "top_p",
-    "min_p",
-    "repetition_penalty",
-    "max_tokens",
-    "worldview",
-    "fiction_markers",
-    "expand_for_texture",
-    "perspective",
-    "verify_entailment",
-    "merge_paragraphs",
-}
-
-
-def _parse_fused_model_config(data: Dict) -> FusedModelConfig:
-    """Parse fused model configuration from dict."""
-    unknown_fields = {
-        k for k in data.keys()
-        if k not in _KNOWN_MODEL_FIELDS and not k.startswith("_")
-    }
-    if unknown_fields:
-        logger.warning(
-            f"Unknown fused-model config fields (ignored): {', '.join(sorted(unknown_fields))}"
-        )
-    return FusedModelConfig(
-        enabled=data.get("enabled", True),
         author=data.get("author", ""),
-        temperature=data.get("temperature", 0.6),
-        top_p=data.get("top_p", 0.92),
-        min_p=data.get("min_p", 0.05),
-        repetition_penalty=data.get("repetition_penalty", 1.15),
-        max_tokens=data.get("max_tokens", 512),
-        worldview=data.get("worldview", ""),
-        fiction_markers=data.get("fiction_markers", []),
-        expand_for_texture=data.get("expand_for_texture"),
-        perspective=data.get("perspective"),
-        verify_entailment=data.get("verify_entailment"),
-        merge_paragraphs=data.get("merge_paragraphs"),
     )
 
 
-def _parse_fused_models(data: Dict) -> Dict[str, FusedModelConfig]:
-    """Parse models section into typed configs."""
+def _parse_fused_models(data: Dict) -> Dict[str, ModelConfig]:
+    """Parse the `generation.models` section into ModelConfig entries."""
     result = {}
     for path, value in data.items():
         if isinstance(value, dict):
-            result[path] = _parse_fused_model_config(value)
+            result[path] = _parse_model_config(value)
     return result
 
 
-def _parse_lora_adapters(data: Dict) -> Dict[str, LoRAAdapterConfig]:
-    """Parse lora_adapters section into typed configs.
+def _parse_lora_adapters(data: Dict) -> Dict[str, ModelConfig]:
+    """Parse `generation.lora_adapters` into ModelConfig entries.
 
-    Handles both old format (path -> scale) and new format (path -> config dict).
+    Supports the legacy `path -> scale` shorthand alongside full dict form.
     """
     result = {}
     for path, value in data.items():
         if isinstance(value, dict):
-            # New format: full config dict
-            result[path] = _parse_lora_adapter_config(value)
+            result[path] = _parse_model_config(value)
         else:
-            # Old format: just a scale number
-            result[path] = LoRAAdapterConfig(scale=float(value))
+            # Legacy shorthand: just a scale number.
+            result[path] = ModelConfig(scale=float(value))
     return result
 
 
@@ -524,17 +464,17 @@ def create_default_config() -> Dict:
     }
 
 
-def get_adapter_config(adapter_path: Optional[str] = None) -> LoRAAdapterConfig:
+def get_adapter_config(adapter_path: Optional[str] = None) -> ModelConfig:
     """Get LoRA adapter config for a specific adapter path.
 
     Args:
         adapter_path: Path to the adapter directory. If None, returns defaults.
 
     Returns:
-        LoRAAdapterConfig for the adapter, or defaults if not found.
+        ModelConfig for the adapter, or defaults if not found.
     """
     if not adapter_path:
-        return LoRAAdapterConfig()
+        return ModelConfig()
 
     try:
         config = load_config()
@@ -555,10 +495,10 @@ def get_adapter_config(adapter_path: Optional[str] = None) -> LoRAAdapterConfig:
     except Exception as e:
         logger.debug(f"Could not load adapter config: {e}")
 
-    return LoRAAdapterConfig()
+    return ModelConfig()
 
 
-def get_fused_model_config(model_path: Optional[str] = None) -> FusedModelConfig:
+def get_fused_model_config(model_path: Optional[str] = None) -> ModelConfig:
     """Get fused-model config for a specific model path.
 
     Mirrors get_adapter_config for the `generation.models` section.
@@ -567,10 +507,10 @@ def get_fused_model_config(model_path: Optional[str] = None) -> FusedModelConfig
         model_path: Path to the fused model directory. If None, returns defaults.
 
     Returns:
-        FusedModelConfig for the model, or defaults if not found.
+        ModelConfig for the model, or defaults if not found.
     """
     if not model_path:
-        return FusedModelConfig()
+        return ModelConfig()
 
     try:
         config = load_config()
@@ -587,4 +527,4 @@ def get_fused_model_config(model_path: Optional[str] = None) -> FusedModelConfig
     except Exception as e:
         logger.debug(f"Could not load fused model config: {e}")
 
-    return FusedModelConfig()
+    return ModelConfig()

--- a/src/generation/base_generator.py
+++ b/src/generation/base_generator.py
@@ -114,7 +114,7 @@ class GenerationConfig:
 
     @classmethod
     def from_fused_model(cls, fused_config) -> "GenerationConfig":
-        """Create GenerationConfig from a FusedModelConfig.
+        """Create GenerationConfig from a fused ModelConfig.
 
         Fused models don't use a scale (LoRA is already merged), so we pin
         scale=1.0 and copy sampling parameters verbatim.

--- a/src/generation/factory.py
+++ b/src/generation/factory.py
@@ -57,6 +57,10 @@ def _set_fiction_markers(generator, model_path: Optional[str]) -> None:
     """
     if not model_path:
         return
+    # Narrow catch: get_*_config already log+default on config errors, so the
+    # only exceptions we expect here are ImportError (module broken) or
+    # AttributeError (non-standard generator). Letting anything else surface
+    # keeps real bugs from being silently swallowed.
     try:
         from ..config import get_adapter_config, get_fused_model_config
 
@@ -67,7 +71,7 @@ def _set_fiction_markers(generator, model_path: Optional[str]) -> None:
         fused_config = get_fused_model_config(model_path)
         if fused_config.fiction_markers:
             generator.fiction_markers = fused_config.fiction_markers
-    except Exception as e:
+    except (ImportError, AttributeError) as e:
         logger.warning(f"Could not load fiction markers: {e}")
 
 

--- a/src/generation/transfer.py
+++ b/src/generation/transfer.py
@@ -18,7 +18,7 @@ import time
 from .lora_generator import AdapterSpec
 from .base_generator import GenerationConfig
 from .factory import create_style_generator
-from ..config import FusedModelConfig, get_adapter_config, get_fused_model_config
+from ..config import ModelConfig, get_adapter_config, get_fused_model_config
 from ..utils.nlp import (
     split_into_paragraphs,
     split_into_sentences,
@@ -57,7 +57,7 @@ logger = get_logger(__name__)
 
 
 def _apply_fused_model_overrides(
-    transfer_config: "TransferConfig", fused_cfg: FusedModelConfig
+    transfer_config: "TransferConfig", fused_cfg: ModelConfig
 ) -> None:
     """Apply per-fused-model overrides to a TransferConfig in place.
 
@@ -94,10 +94,10 @@ def _apply_fused_model_overrides(
 class TransferConfig:
     """Configuration for style transfer."""
 
-    # Generation settings
-    max_tokens: int = 512
-    temperature: Optional[float] = None  # None = use lora config, float = CLI override
-    top_p: float = 0.9
+    # Temperature override from CLI (None = use per-adapter/model config).
+    # Other sampling params (max_tokens, top_p, min_p, repetition_penalty)
+    # live on GenerationConfig and are driven by the model entry in config.json.
+    temperature: Optional[float] = None
 
     # Semantic fidelity validation (single DeepSeek call replaces NLI + repair + grammar + repetition)
     verify_semantic_fidelity: bool = True

--- a/src/generation/transfer.py
+++ b/src/generation/transfer.py
@@ -251,6 +251,15 @@ class StyleTransfer:
         # models so _get_worldview_filename can locate the config entry.
         self.adapter_path = primary_adapter_path
 
+        # Validate persona file at startup so a typo in config.worldview fails
+        # fast instead of aborting mid-document on the first paragraph.
+        if self.config.use_persona and PERSONA_AVAILABLE:
+            from ..persona.prompt_builder import (
+                _get_worldview_filename,
+                _load_persona_file,
+            )
+            _load_persona_file(_get_worldview_filename(self.adapter_path))
+
         if fused_models:
             fused_cfg = get_fused_model_config(primary_adapter_path)
             gen_config = GenerationConfig.from_fused_model(fused_cfg)

--- a/src/llm/mlx_provider.py
+++ b/src/llm/mlx_provider.py
@@ -5,6 +5,7 @@ This allows the entire pipeline to be self-contained without external services.
 """
 
 import json
+import re
 import time
 from typing import Optional, Callable
 from pathlib import Path
@@ -399,6 +400,45 @@ class RTTNeutralizer(BaseRTTNeutralizer):
 
         return response.strip()
 
+    def _rtt_once(self, text: str, word_count: int) -> Optional[str]:
+        """Single pass through RTT: English → Mandarin → Plain English.
+
+        Step 1 ("Acid Bath") strips Victorian/Lovecraftian syntax via HSK5
+        Mandarin. Step 2 ("Flattener") emits clinical SVO English. Code fences
+        are stripped; Chinese residue marks a failure. Length validation is
+        left to the caller so that long single-sentence chunks (called via
+        _do_neutralize) aren't rejected by the <100-word variance check.
+        """
+        max_mandarin_tokens = min(int(word_count * 2), 512)
+        mandarin = self._generate(
+            system=load_prompt("rtt_to_mandarin"),
+            user=f"Translate to simple Mandarin:\n\n{text}",
+            max_tokens=max_mandarin_tokens,
+        )
+        if not mandarin or len(mandarin) < 10:
+            logger.debug("RTT Step 1 failed: empty Mandarin")
+            return None
+
+        max_english_tokens = min(int(word_count * 1.5) + 20, 400)
+        english = self._generate(
+            system=load_prompt("rtt_to_english"),
+            user=f"Translate to simple English:\n\n{mandarin}",
+            max_tokens=max_english_tokens,
+        )
+        if not english or len(english) < 10:
+            logger.debug("RTT Step 2 failed: empty English")
+            return None
+
+        english = english.strip()
+        english = re.sub(r'^```\w*\n?', '', english)
+        english = re.sub(r'\n?```$', '', english)
+
+        if re.search(r'[\u4e00-\u9fff]', english):
+            logger.debug("RTT Step 2 failed: output contains Chinese")
+            return None
+
+        return english
+
     def neutralize(
         self,
         text: str,
@@ -418,9 +458,6 @@ class RTTNeutralizer(BaseRTTNeutralizer):
         Returns:
             Neutralized text, or None if failed.
         """
-        import re
-
-        # Extract and mask entities before RTT
         masked_text, entity_map = self._extract_entities(text)
         if entity_map:
             logger.debug(f"Masked {len(entity_map)} entities: {list(entity_map.values())[:5]}...")
@@ -436,69 +473,27 @@ class RTTNeutralizer(BaseRTTNeutralizer):
 
         for attempt in range(max_retries):
             try:
-                # Step 1: English → Mandarin ("Acid Bath" - strips Victorian syntax)
-                # HSK5 vocabulary constraint forces simple word choices
-                # Entity placeholders preserved through RTT
-                max_mandarin_tokens = min(int(word_count * 2), 512)
-                rtt_mandarin_prompt = load_prompt("rtt_to_mandarin")
-                mandarin = self._generate(
-                    system=rtt_mandarin_prompt,
-                    user=f"Translate to simple Mandarin:\n\n{masked_text}",
-                    max_tokens=max_mandarin_tokens,
-                )
-
-                if not mandarin or len(mandarin) < 10:
-                    logger.debug(f"RTT Step 1 failed: empty Mandarin (attempt {attempt + 1})")
+                english = self._rtt_once(masked_text, word_count)
+                if english is None:
                     continue
 
-                # Step 2: Mandarin → Plain English ("Flattener" - clinical SVO output)
-                # Controlled English: short sentences, common words, monotonous tone
-                max_english_tokens = min(int(word_count * 1.5) + 20, 400)
-                rtt_english_prompt = load_prompt("rtt_to_english")
-                english = self._generate(
-                    system=rtt_english_prompt,
-                    user=f"Translate to simple English:\n\n{mandarin}",
-                    max_tokens=max_english_tokens,
-                )
-
-                if not english or len(english) < 10:
-                    logger.debug(f"RTT Step 2 failed: empty English (attempt {attempt + 1})")
-                    continue
-
-                # Clean response
-                english = english.strip()
-                english = re.sub(r'^```\w*\n?', '', english)
-                english = re.sub(r'\n?```$', '', english)
-
-                # Check for Chinese characters (translation failed if present)
-                if re.search(r'[\u4e00-\u9fff]', english):
-                    logger.debug(f"RTT Step 2 failed: output contains Chinese (attempt {attempt + 1})")
-                    continue
-
-                # Validate length (lenient for long texts)
+                # Length validation (only applied here — long single-sentence
+                # chunks go via _do_neutralize and skip this check).
                 neutral_words = len(english.split())
                 if neutral_words < 3:
-                    # Too short - generation failed
                     logger.debug(f"RTT too short: {neutral_words} words (attempt {attempt + 1})")
                     continue
 
-                # Length validation: more lenient for long texts
-                # Short texts (<100w): allow 2x variance
-                # Long texts (>100w): allow any reasonable output (truncation ok)
-                if word_count < 100:
-                    max_diff = word_count * 1.0
-                else:
-                    max_diff = word_count * 2.0  # Very lenient for long texts
-
+                max_diff = word_count * 1.0 if word_count < 100 else word_count * 2.0
                 if abs(neutral_words - word_count) > max_diff:
-                    logger.debug(f"RTT length mismatch: {neutral_words} vs {word_count} (attempt {attempt + 1})")
+                    logger.debug(
+                        f"RTT length mismatch: {neutral_words} vs {word_count} (attempt {attempt + 1})"
+                    )
                     continue
 
-                # Step 3 (optional): Monotone flattening for training burstiness
                 if monotone:
                     english = self._monotone_flatten(english)
 
-                # Step 4: Restore original proper nouns
                 if entity_map:
                     english = self._restore_entities(english, entity_map)
 
@@ -516,47 +511,18 @@ class RTTNeutralizer(BaseRTTNeutralizer):
         max_retries: int = 2,
         monotone: bool = False,
     ) -> Optional[str]:
-        """Core RTT neutralization without chunking.
+        """Core RTT neutralization without chunking or length validation.
 
         Called directly for chunks that are >300 words but can't be split further
-        (e.g., single sentences with no period boundaries).
+        (e.g., single sentences with no period boundaries). Entity masking is
+        the caller's responsibility.
         """
-        import re
-
         word_count = len(text.split())
 
         for attempt in range(max_retries):
             try:
-                max_mandarin_tokens = min(int(word_count * 2), 512)
-                rtt_mandarin_prompt = load_prompt("rtt_to_mandarin")
-                mandarin = self._generate(
-                    system=rtt_mandarin_prompt,
-                    user=f"Translate to simple Mandarin:\n\n{text}",
-                    max_tokens=max_mandarin_tokens,
-                )
-
-                if not mandarin or len(mandarin) < 10:
-                    logger.debug(f"RTT Step 1 failed: empty Mandarin (attempt {attempt + 1})")
-                    continue
-
-                max_english_tokens = min(int(word_count * 1.5) + 20, 400)
-                rtt_english_prompt = load_prompt("rtt_to_english")
-                english = self._generate(
-                    system=rtt_english_prompt,
-                    user=f"Translate to simple English:\n\n{mandarin}",
-                    max_tokens=max_english_tokens,
-                )
-
-                if not english or len(english) < 10:
-                    logger.debug(f"RTT Step 2 failed: empty English (attempt {attempt + 1})")
-                    continue
-
-                english = english.strip()
-                english = re.sub(r'^```\w*\n?', '', english)
-                english = re.sub(r'\n?```$', '', english)
-
-                if re.search(r'[\u4e00-\u9fff]', english):
-                    logger.debug(f"RTT Step 2 failed: output contains Chinese (attempt {attempt + 1})")
+                english = self._rtt_once(text, word_count)
+                if english is None:
                     continue
 
                 neutral_words = len(english.split())
@@ -917,8 +883,6 @@ class DeepSeekRTTNeutralizer(BaseRTTNeutralizer):
             retry_counts[idx] = 0
 
         total_items = len(texts)
-        active_workers = [self.concurrent_batches]  # Track active workers
-        workers_lock = threading.Lock()
 
         logger.info(f"Processing {len(texts)} texts with queue-based pipeline "
                    f"(batch_size={self.batch_size}, workers={self.concurrent_batches}, max_retries={max_retries})")
@@ -1004,9 +968,6 @@ class DeepSeekRTTNeutralizer(BaseRTTNeutralizer):
                                 logger.debug(f"[{orig_idx}] Failed after {max_retries} attempts (worker error)")
                         else:
                             work_queue.put((orig_idx, text, retry_counts[orig_idx]))
-
-            with workers_lock:
-                active_workers[0] -= 1
 
         # Start workers
         with ThreadPoolExecutor(max_workers=self.concurrent_batches) as executor:

--- a/src/vocabulary/grammar_corrector.py
+++ b/src/vocabulary/grammar_corrector.py
@@ -160,25 +160,23 @@ class GrammarCorrector:
 
         return False
 
-    def _apply_corrections(self, text: str, matches: List) -> str:
+    def _apply_corrections(self, text: str, matches: List) -> Tuple[str, int]:
         """Apply corrections from matches to text.
 
-        Applies corrections in reverse order to preserve offsets.
-
-        Args:
-            text: Original text.
-            matches: List of filtered matches to apply.
+        Applies corrections in reverse order to preserve offsets. Skips matches
+        with no replacements or replacements rejected by the safety guard.
 
         Returns:
-            Corrected text.
+            Tuple of (corrected_text, applied_count). applied_count reflects
+            writes actually performed, not the input match count.
         """
         if not matches:
-            return text
+            return text, 0
 
-        # Sort by offset descending to apply from end to start
         sorted_matches = sorted(matches, key=lambda m: m.offset, reverse=True)
 
         result = text
+        applied = 0
         for match in sorted_matches:
             if not match.replacements:
                 continue
@@ -188,8 +186,9 @@ class GrammarCorrector:
             start = match.offset
             end = match.offset + match.error_length
             result = result[:start] + replacement + result[end:]
+            applied += 1
 
-        return result
+        return result, applied
 
     @staticmethod
     def _is_safe_replacement(replacement: str, error_length: int) -> bool:
@@ -242,8 +241,7 @@ class GrammarCorrector:
                 return text, stats
 
             # Apply corrections
-            corrected = self._apply_corrections(text, filtered)
-            stats.corrections_applied = len(filtered)
+            corrected, stats.corrections_applied = self._apply_corrections(text, filtered)
 
             if corrected != text:
                 logger.debug(

--- a/tests/unit/test_factory.py
+++ b/tests/unit/test_factory.py
@@ -1,7 +1,10 @@
 """Tests for generator factory module.
 
 Tests cover:
-- Bug 5: Silent exception swallowing in _set_fiction_markers
+- Fiction marker loading: config errors handled internally by get_adapter_config
+  / get_fused_model_config (they catch and return defaults). The factory's own
+  exception handling is narrowed to (ImportError, AttributeError) so that
+  unexpected errors surface instead of being silently swallowed.
 """
 
 import pytest
@@ -9,20 +12,37 @@ from unittest.mock import patch, MagicMock
 
 
 class TestFictionMarkerLogging:
-    """Tests for Bug 5: Fiction marker loading failure should be logged."""
+    """Tests for _set_fiction_markers exception handling."""
 
-    def test_fiction_marker_failure_logged(self):
-        """When get_adapter_config raises, warning should be logged."""
+    def test_fiction_marker_attribute_error_logged(self):
+        """AttributeError when setting fiction_markers should be caught and logged."""
+        from src.generation.factory import _set_fiction_markers
+        from src.config import ModelConfig
+
+        # Generator that raises AttributeError on attribute assignment
+        class RigidGenerator:
+            __slots__ = ()
+
+        generator = RigidGenerator()
+
+        with patch('src.config.get_adapter_config',
+                   return_value=ModelConfig(fiction_markers=["marker1"])):
+            with patch('src.generation.factory.logger') as mock_logger:
+                _set_fiction_markers(generator, "some/adapter/path")
+
+        mock_logger.warning.assert_called_once()
+        assert "fiction markers" in str(mock_logger.warning.call_args).lower()
+
+    def test_fiction_marker_unexpected_errors_propagate(self):
+        """Non-(ImportError, AttributeError) exceptions must surface as real bugs,
+        not be silently swallowed. Config errors are already handled internally."""
         from src.generation.factory import _set_fiction_markers
 
         mock_generator = MagicMock()
 
-        with patch('src.config.get_adapter_config', side_effect=RuntimeError("config error")):
-            with patch('src.generation.factory.logger') as mock_logger:
+        with patch('src.config.get_adapter_config', side_effect=RuntimeError("boom")):
+            with pytest.raises(RuntimeError, match="boom"):
                 _set_fiction_markers(mock_generator, "some/adapter/path")
-
-        mock_logger.warning.assert_called_once()
-        assert "fiction markers" in str(mock_logger.warning.call_args).lower()
 
     def test_fiction_marker_success_no_warning(self):
         """When get_adapter_config succeeds, no warning should be logged."""

--- a/tests/unit/test_grammar_corrector.py
+++ b/tests/unit/test_grammar_corrector.py
@@ -163,9 +163,10 @@ class TestGrammarCorrector:
         corrector = GrammarCorrector()
         text = "This is a test."
 
-        result = corrector._apply_corrections(text, [])
+        result, applied = corrector._apply_corrections(text, [])
 
         assert result == text
+        assert applied == 0
 
     def test_apply_corrections_single_match(self):
         """Test applying a single correction."""
@@ -179,9 +180,10 @@ class TestGrammarCorrector:
         mock_match.error_length = 4  # Length of "were"
         mock_match.replacements = ["was"]
 
-        result = corrector._apply_corrections(text, [mock_match])
+        result, applied = corrector._apply_corrections(text, [mock_match])
 
         assert result == "The horror was lurking."
+        assert applied == 1
 
     def test_apply_corrections_multiple_matches(self):
         """Test applying multiple corrections in correct order."""
@@ -202,9 +204,10 @@ class TestGrammarCorrector:
         match2.error_length = 3
         match2.replacements = ["the"]
 
-        result = corrector._apply_corrections(text, [match1, match2])
+        result, applied = corrector._apply_corrections(text, [match1, match2])
 
         assert result == "She doesn't like the food."
+        assert applied == 2
 
     def test_analyze_empty_when_unavailable(self):
         """Test that analyze returns empty list when unavailable."""
@@ -366,8 +369,9 @@ class TestReplacementGuards:
         mock_match.error_length = 6  # "horror"
         mock_match.replacements = [""]  # Empty replacement
 
-        result = corrector._apply_corrections(text, [mock_match])
+        result, applied = corrector._apply_corrections(text, [mock_match])
         assert result == text, "Empty replacement should not delete text"
+        assert applied == 0
 
     def test_suspiciously_long_replacement_rejected(self):
         """Replacement dramatically longer than the error should be skipped."""
@@ -384,10 +388,11 @@ class TestReplacementGuards:
             "was lurking, its presence an indescribable shadow upon the night"
         ]
 
-        result = corrector._apply_corrections(text, [mock_match])
+        result, applied = corrector._apply_corrections(text, [mock_match])
         assert result == text, (
             f"Suspiciously long replacement should be skipped, got: {result}"
         )
+        assert applied == 0
 
     def test_normal_replacement_still_applied(self):
         """Short, sane replacements (e.g., were -> was) should still apply."""
@@ -401,8 +406,9 @@ class TestReplacementGuards:
         mock_match.error_length = 4  # "were"
         mock_match.replacements = ["was"]
 
-        result = corrector._apply_corrections(text, [mock_match])
+        result, applied = corrector._apply_corrections(text, [mock_match])
         assert result == "The horror was lurking."
+        assert applied == 1
 
     def test_slightly_longer_replacement_applied(self):
         """Slightly longer replacement (dont -> doesn't) should be allowed."""
@@ -416,8 +422,82 @@ class TestReplacementGuards:
         mock_match.error_length = 4  # "dont"
         mock_match.replacements = ["doesn't"]  # 7 chars — < 3x
 
-        result = corrector._apply_corrections(text, [mock_match])
+        result, applied = corrector._apply_corrections(text, [mock_match])
         assert result == "She doesn't know."
+        assert applied == 1
+
+
+class TestCorrectionsAppliedCounterAccuracy:
+    """Review finding: stats.corrections_applied was set to len(filtered),
+    but _apply_corrections skips matches with no replacements and matches
+    rejected by the safety guard. The counter was lying about work done."""
+
+    def _make_match(self, offset, error_length, replacements):
+        m = MagicMock()
+        m.offset = offset
+        m.error_length = error_length
+        m.replacements = replacements
+        m.category = "GRAMMAR"
+        m.rule_id = "RULE"
+        return m
+
+    def test_counter_excludes_empty_replacement_matches(self):
+        """A match with [''] replacements gets skipped but used to be counted."""
+        from src.vocabulary.grammar_corrector import GrammarCorrector
+
+        corrector = GrammarCorrector()
+        corrector._available = True
+
+        safe_match = self._make_match(0, 3, ["was"])  # "The" -> "was" (applied)
+        empty_match = self._make_match(10, 6, [""])  # skipped
+
+        mock_tool = MagicMock()
+        mock_tool.check.return_value = [safe_match, empty_match]
+        corrector._tool = mock_tool
+
+        _, stats = corrector.correct("The horror were lurking.")
+
+        assert stats.corrections_applied == 1, (
+            "Counter should reflect replacements actually written, "
+            f"not the pre-filter match count. Got {stats.corrections_applied}"
+        )
+
+    def test_counter_excludes_missing_replacements(self):
+        """A match with [] replacements gets skipped but used to be counted."""
+        from src.vocabulary.grammar_corrector import GrammarCorrector
+
+        corrector = GrammarCorrector()
+        corrector._available = True
+
+        no_repl_match = self._make_match(0, 5, [])  # skipped: no replacement
+
+        mock_tool = MagicMock()
+        mock_tool.check.return_value = [no_repl_match]
+        corrector._tool = mock_tool
+
+        _, stats = corrector.correct("Some text here for testing.")
+
+        assert stats.corrections_applied == 0
+
+    def test_counter_excludes_unsafe_long_replacements(self):
+        """A match the safety guard rejects gets skipped but used to be counted."""
+        from src.vocabulary.grammar_corrector import GrammarCorrector
+
+        corrector = GrammarCorrector()
+        corrector._available = True
+
+        unsafe_match = self._make_match(
+            0, 3,
+            ["a sprawling whole-sentence rewrite that would rewrite all of this"],
+        )
+
+        mock_tool = MagicMock()
+        mock_tool.check.return_value = [unsafe_match]
+        corrector._tool = mock_tool
+
+        _, stats = corrector.correct("The quick brown fox jumps over.")
+
+        assert stats.corrections_applied == 0
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_mlx_provider.py
+++ b/tests/unit/test_mlx_provider.py
@@ -75,6 +75,61 @@ class TestNeutralizeChunked:
         assert result is not None
 
 
+class TestRttOnceHelper:
+    """_rtt_once: single pass through Mandarin→English, shared by neutralize()
+    and _do_neutralize() to eliminate the ~60-line duplicated loop body."""
+
+    def _provider(self):
+        from src.llm.mlx_provider import RTTNeutralizer
+        provider = RTTNeutralizer.__new__(RTTNeutralizer)
+        provider._model = None
+        provider._tokenizer = None
+        return provider
+
+    def test_empty_mandarin_returns_none(self):
+        provider = self._provider()
+        provider._generate = MagicMock(side_effect=["", "unused"])
+
+        result = provider._rtt_once("some English text here.", word_count=4)
+        assert result is None
+
+    def test_empty_english_returns_none(self):
+        provider = self._provider()
+        provider._generate = MagicMock(side_effect=["mandarin output", ""])
+
+        result = provider._rtt_once("some English text here.", word_count=4)
+        assert result is None
+
+    def test_chinese_residue_returns_none(self):
+        """If the Mandarin→English step leaks Chinese characters, pass failed."""
+        provider = self._provider()
+        provider._generate = MagicMock(
+            side_effect=["some mandarin", "mixed with 中文 characters here"]
+        )
+
+        result = provider._rtt_once("source text.", word_count=3)
+        assert result is None
+
+    def test_strips_code_fences(self):
+        """Leading/trailing ``` fences should be stripped from the output."""
+        provider = self._provider()
+        provider._generate = MagicMock(
+            side_effect=["some mandarin text", "```\nplain english output\n```"]
+        )
+
+        result = provider._rtt_once("source.", word_count=2)
+        assert result == "plain english output"
+
+    def test_success_returns_cleaned_english(self):
+        provider = self._provider()
+        provider._generate = MagicMock(
+            side_effect=["mandarin translation", "  clean english output  "]
+        )
+
+        result = provider._rtt_once("source here.", word_count=3)
+        assert result == "clean english output"
+
+
 class TestNeutralizerSharedMethodParity:
     """Pin that MLX and DeepSeek neutralizers agree on the pure helper methods.
 
@@ -149,6 +204,26 @@ class TestNeutralizerSharedMethodParity:
         masked, entity_map = mlx_neutralizer._extract_entities("The door opened.")
         assert "__ENT" not in masked
         assert entity_map == {}
+
+
+class TestDeadActiveWorkersRemoved:
+    """Regression guard for the dead `active_workers`/`workers_lock` counter that
+    was written but never read. Removing them lets the ThreadPoolExecutor join
+    naturally and cuts one class of future drift (a reader adding logic that
+    relies on the stale counter)."""
+
+    def test_no_active_workers_counter(self):
+        import inspect
+        from src.llm import mlx_provider
+
+        source = inspect.getsource(mlx_provider)
+        assert "active_workers" not in source, (
+            "active_workers counter was dead code — never read. "
+            "ThreadPoolExecutor.futures already tracks completion."
+        )
+        assert "workers_lock" not in source, (
+            "workers_lock guarded only the dead active_workers counter."
+        )
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_transfer.py
+++ b/tests/unit/test_transfer.py
@@ -625,6 +625,65 @@ class TestDeadCodeLoraInputWords:
         )
 
 
+class TestPersonaStartupValidation:
+    """A typo in config.worldview should fail fast at StyleTransfer init, not
+    mid-document when the first paragraph tries to load the persona file."""
+
+    @patch('src.generation.transfer.create_style_generator')
+    def test_init_raises_on_missing_persona_file(self, mock_generator_class, tmp_path):
+        """StyleTransfer.__init__ should raise FileNotFoundError when worldview
+        points to a missing file and use_persona is True."""
+        from src.generation.transfer import StyleTransfer, TransferConfig
+        from src.persona.prompt_builder import _load_persona_file
+
+        _load_persona_file.cache_clear()
+        mock_critic = MagicMock()
+        mock_critic.provider_name = "mock"
+
+        config = TransferConfig(verify_semantic_fidelity=False, use_persona=True)
+
+        # Point the worldview lookup at a filename that doesn't exist.
+        with patch(
+            'src.persona.prompt_builder._get_worldview_filename',
+            return_value='totally_missing_persona_file.txt',
+        ):
+            with pytest.raises(FileNotFoundError, match="totally_missing_persona_file"):
+                StyleTransfer(
+                    adapter_path="lora_adapters/test",
+                    author_name="Test",
+                    critic_provider=mock_critic,
+                    config=config,
+                )
+
+    @patch('src.generation.transfer.create_style_generator')
+    def test_init_skips_persona_validation_when_use_persona_false(
+        self, mock_generator_class, tmp_path
+    ):
+        """When use_persona is False, init should succeed even if the worldview
+        file would be missing — the persona path is never taken."""
+        from src.generation.transfer import StyleTransfer, TransferConfig
+        from src.persona.prompt_builder import _load_persona_file
+
+        _load_persona_file.cache_clear()
+        mock_critic = MagicMock()
+        mock_critic.provider_name = "mock"
+
+        config = TransferConfig(verify_semantic_fidelity=False, use_persona=False)
+
+        with patch(
+            'src.persona.prompt_builder._get_worldview_filename',
+            return_value='totally_missing_persona_file.txt',
+        ):
+            # Should NOT raise — persona is disabled
+            transfer = StyleTransfer(
+                adapter_path="lora_adapters/test",
+                author_name="Test",
+                critic_provider=mock_critic,
+                config=config,
+            )
+            assert transfer.author == "Test"
+
+
 class TestCleanPunctuationAbbreviations:
     """Bug: _clean_punctuation_artifacts breaks abbreviations like U.S. -> U. S."""
 

--- a/tests/unit/test_transfer.py
+++ b/tests/unit/test_transfer.py
@@ -26,10 +26,24 @@ class TestTransferConfig:
 
         config = TransferConfig()
 
-        assert config.max_tokens == 512
         assert config.temperature is None  # None means use lora config
-        assert config.top_p == 0.9
         assert config.verify_semantic_fidelity is True
+
+    def test_sampling_params_live_on_generation_config_not_transfer(self):
+        """max_tokens / top_p belong on GenerationConfig. TransferConfig used to
+        carry parallel unused copies — C5 removed them. Regression guard so
+        they can't sneak back in."""
+        from src.generation.transfer import TransferConfig
+
+        config = TransferConfig()
+        assert not hasattr(config, "max_tokens"), (
+            "TransferConfig.max_tokens was unused dead weight; "
+            "sampling params live on GenerationConfig only."
+        )
+        assert not hasattr(config, "top_p"), (
+            "TransferConfig.top_p was unused dead weight; "
+            "sampling params live on GenerationConfig only."
+        )
 
     def test_custom_values(self):
         """Test that custom values are applied."""

--- a/tests/unit/test_unified_model_config.py
+++ b/tests/unit/test_unified_model_config.py
@@ -1,0 +1,168 @@
+"""Tests for C4: unified ModelConfig dataclass.
+
+LoRAAdapterConfig and FusedModelConfig had near-identical fields with only
+two distinct concerns: LoRA-specific options (scale, backend, quantization)
+and the fused-only `author` field. Collapse them into one ModelConfig and
+keep the old names as aliases so external call sites don't break.
+"""
+
+import json
+import os
+import tempfile
+
+
+class TestModelConfigExists:
+    """ModelConfig should be importable and carry all fields."""
+
+    def test_model_config_importable(self):
+        from src.config import ModelConfig
+
+        cfg = ModelConfig()
+        assert cfg is not None
+
+    def test_model_config_has_lora_fields(self):
+        """LoRA-specific fields from LoRAAdapterConfig should live on ModelConfig."""
+        from src.config import ModelConfig
+
+        cfg = ModelConfig()
+        assert hasattr(cfg, "scale")
+        assert hasattr(cfg, "checkpoint")
+        assert hasattr(cfg, "backend")
+        assert hasattr(cfg, "device")
+        assert hasattr(cfg, "load_in_4bit")
+        assert hasattr(cfg, "load_in_8bit")
+        assert hasattr(cfg, "hf_adapter_path")
+
+    def test_model_config_has_fused_fields(self):
+        """Fused-specific fields from FusedModelConfig should live on ModelConfig."""
+        from src.config import ModelConfig
+
+        cfg = ModelConfig()
+        assert hasattr(cfg, "author")
+
+    def test_model_config_has_shared_fields(self):
+        """All shared fields should exist on ModelConfig."""
+        from src.config import ModelConfig
+
+        cfg = ModelConfig()
+        for name in (
+            "enabled",
+            "temperature",
+            "top_p",
+            "min_p",
+            "repetition_penalty",
+            "max_tokens",
+            "worldview",
+            "fiction_markers",
+            "expand_for_texture",
+            "perspective",
+            "verify_entailment",
+            "merge_paragraphs",
+        ):
+            assert hasattr(cfg, name), f"ModelConfig missing field: {name}"
+
+
+class TestBackwardsCompatAliases:
+    """LoRAAdapterConfig and FusedModelConfig must still be importable as aliases."""
+
+    def test_lora_adapter_config_is_model_config(self):
+        from src.config import LoRAAdapterConfig, ModelConfig
+
+        assert LoRAAdapterConfig is ModelConfig
+
+    def test_fused_model_config_is_model_config(self):
+        from src.config import FusedModelConfig, ModelConfig
+
+        assert FusedModelConfig is ModelConfig
+
+
+class TestGetConfigReturnTypes:
+    """get_adapter_config and get_fused_model_config should return ModelConfig."""
+
+    def test_get_adapter_config_returns_model_config(self):
+        from src.config import ModelConfig, get_adapter_config
+
+        cfg = get_adapter_config(None)
+        assert isinstance(cfg, ModelConfig)
+
+    def test_get_fused_model_config_returns_model_config(self):
+        from src.config import ModelConfig, get_fused_model_config
+
+        cfg = get_fused_model_config(None)
+        assert isinstance(cfg, ModelConfig)
+
+
+class TestUnifiedParsing:
+    """Unified parser should parse both lora_adapters and models entries."""
+
+    def test_parse_lora_adapter_entry_with_all_fields(self):
+        from src.config import _config_cache, get_adapter_config, load_config
+
+        config_data = {
+            "llm": {"provider": {"writer": "mlx", "critic": "deepseek"}, "providers": {}},
+            "generation": {
+                "lora_adapters": {
+                    "lora/custom": {
+                        "scale": 1.7,
+                        "temperature": 0.55,
+                        "worldview": "custom.txt",
+                        "fiction_markers": ["m1"],
+                    }
+                }
+            },
+        }
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(config_data, f)
+            f.flush()
+            try:
+                _config_cache.clear()
+                cfg = load_config(f.name)
+                _config_cache["config.json"] = cfg
+
+                adapter = get_adapter_config("lora/custom")
+                assert adapter.scale == 1.7
+                assert adapter.temperature == 0.55
+                assert adapter.worldview == "custom.txt"
+                assert adapter.fiction_markers == ["m1"]
+            finally:
+                _config_cache.clear()
+                os.unlink(f.name)
+
+    def test_parse_fused_model_entry_with_author(self):
+        from src.config import _config_cache, get_fused_model_config, load_config
+
+        config_data = {
+            "llm": {"provider": {"writer": "mlx", "critic": "deepseek"}, "providers": {}},
+            "generation": {
+                "use_adapter": False,
+                "models": {
+                    "models/baz": {
+                        "author": "Baz Author",
+                        "temperature": 0.3,
+                        "worldview": "baz.txt",
+                    }
+                },
+            },
+        }
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(config_data, f)
+            f.flush()
+            try:
+                _config_cache.clear()
+                cfg = load_config(f.name)
+                _config_cache["config.json"] = cfg
+
+                model = get_fused_model_config("models/baz")
+                assert model.author == "Baz Author"
+                assert model.temperature == 0.3
+                assert model.worldview == "baz.txt"
+            finally:
+                _config_cache.clear()
+                os.unlink(f.name)
+
+
+if __name__ == "__main__":
+    import pytest
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
…trim TransferConfig

C4 — LoRA adapter entries and fused-model entries shared ~14 fields with small, disjoint extensions (scale/backend/quant for LoRA; author for fused). Two dataclasses + two parsers + two known-field sets was pure duplication.

Collapse to a single ModelConfig with LoRA-only fields at defaults for fused usage. Keep LoRAAdapterConfig and FusedModelConfig as aliases so existing imports and isinstance checks continue to work. One parser, one known-fields set, one return type for get_adapter_config and get_fused_model_config.

C5 — TransferConfig.max_tokens and TransferConfig.top_p were never read: generators consume sampling params from GenerationConfig. Drop the dead fields; add a regression guard so they don't sneak back in.