### PR TITLE
refactor: replace module-global singletons with Services container

### DIFF
--- a/src/generation/transfer.py
+++ b/src/generation/transfer.py
@@ -11,9 +11,12 @@ Pipeline:
 """
 
 from dataclasses import dataclass, field
-from typing import List, Optional, Callable, Tuple
+from typing import List, Optional, Callable, Tuple, TYPE_CHECKING
 import re
 import time
+
+if TYPE_CHECKING:
+    from ..services import Services
 
 from .lora_generator import AdapterSpec
 from .base_generator import GenerationConfig
@@ -205,6 +208,7 @@ class StyleTransfer:
         checkpoint: Optional[str] = None,
         adapters: Optional[List[AdapterSpec]] = None,
         fused_models: Optional[List[str]] = None,
+        services: Optional["Services"] = None,
     ):
         """Initialize the fast transfer pipeline.
 
@@ -217,10 +221,17 @@ class StyleTransfer:
             checkpoint: Specific checkpoint file to use (e.g., "0000600_adapters.safetensors").
             adapters: List of AdapterSpec for multiple adapters. If provided, adapter_path is ignored.
             fused_models: List of fused model paths to use directly (no adapter needed).
+            services: Optional Services container for dependency injection. If
+                None, the process-wide default from get_default_services() is used.
         """
         self.config = config or TransferConfig()
         self.author = author_name
         self.verify_fn = verify_fn
+
+        if services is None:
+            from ..services import get_default_services
+            services = get_default_services()
+        self.services = services
 
         # Convert string provider name to actual LLMProvider object if needed
         if isinstance(critic_provider, str):
@@ -807,9 +818,7 @@ class StyleTransfer:
         Returns ratio of input content words found in output.
         Low overlap suggests memorized/hallucinated output.
         """
-        from ..utils.nlp import get_nlp
-
-        nlp = get_nlp()
+        nlp = self.services.nlp
 
         def get_content_words(text: str) -> set:
             """Extract lemmatized content words using spaCy."""

--- a/src/rag/corpus_indexer.py
+++ b/src/rag/corpus_indexer.py
@@ -15,65 +15,77 @@ from .style_analyzer import StyleAnalyzer, StyleMetrics
 
 logger = get_logger(__name__)
 
-# Lazy-loaded modules
-_chromadb = None
-_sentence_transformer = None
+def _load_chromadb():
+    """Import and return the chromadb module. Called once per Services
+    container (cached on `Services._chromadb`)."""
+    try:
+        import chromadb
+        return chromadb
+    except ImportError:
+        raise ImportError("chromadb required. Install with: pip install chromadb")
+
+
+def _load_embedding_model():
+    """Load the shared SentenceTransformer with stdout/stderr/tqdm suppressed.
+    Called once per Services container (cached on `Services._embedding_model`)."""
+    try:
+        import sys
+        import os
+        import warnings
+        import logging
+        from io import StringIO
+
+        # Disable tqdm before importing sentence_transformers
+        os.environ["TQDM_DISABLE"] = "1"
+        from sentence_transformers import SentenceTransformer
+
+        # Suppress noisy warnings and stdout during model loading
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore")
+            st_logger = logging.getLogger("sentence_transformers")
+            tf_logger = logging.getLogger("transformers")
+            old_st_level = st_logger.level
+            old_tf_level = tf_logger.level
+            st_logger.setLevel(logging.ERROR)
+            tf_logger.setLevel(logging.ERROR)
+            old_stdout, old_stderr = sys.stdout, sys.stderr
+            sys.stdout = StringIO()
+            sys.stderr = StringIO()
+            try:
+                model = SentenceTransformer("all-MiniLM-L6-v2")
+            finally:
+                sys.stdout, sys.stderr = old_stdout, old_stderr
+                st_logger.setLevel(old_st_level)
+                tf_logger.setLevel(old_tf_level)
+
+        logger.debug("Loaded sentence transformer: all-MiniLM-L6-v2")
+        return model
+    except ImportError:
+        raise ImportError(
+            "sentence-transformers required. Install with: pip install sentence-transformers"
+        )
+
+
+def _default_indexer_path() -> str:
+    """Project-local default ChromaDB path."""
+    return str(Path(__file__).parent.parent.parent / "data" / "rag_index")
+
+
+def _load_default_indexer() -> "CorpusIndexer":
+    """Construct the shared default indexer pointed at the project data dir."""
+    return CorpusIndexer(_default_indexer_path())
 
 
 def get_chromadb():
-    """Lazy-load ChromaDB."""
-    global _chromadb
-    if _chromadb is None:
-        try:
-            import chromadb
-            _chromadb = chromadb
-        except ImportError:
-            raise ImportError("chromadb required. Install with: pip install chromadb")
-    return _chromadb
+    """Return the chromadb module from the default Services container."""
+    from ..services import get_default_services
+    return get_default_services().chromadb
 
 
 def get_embedding_model():
-    """Lazy-load sentence transformer model."""
-    global _sentence_transformer
-    if _sentence_transformer is None:
-        try:
-            import sys
-            import os
-            import warnings
-            import logging
-            from io import StringIO
-
-            # Disable tqdm before importing sentence_transformers
-            os.environ["TQDM_DISABLE"] = "1"
-            from sentence_transformers import SentenceTransformer
-
-            # Suppress noisy warnings and stdout during model loading
-            with warnings.catch_warnings():
-                warnings.filterwarnings("ignore")
-                # Suppress sentence_transformers and transformers logging
-                st_logger = logging.getLogger("sentence_transformers")
-                tf_logger = logging.getLogger("transformers")
-                old_st_level = st_logger.level
-                old_tf_level = tf_logger.level
-                st_logger.setLevel(logging.ERROR)
-                tf_logger.setLevel(logging.ERROR)
-                # Suppress stdout/stderr (for LOAD REPORT)
-                old_stdout, old_stderr = sys.stdout, sys.stderr
-                sys.stdout = StringIO()
-                sys.stderr = StringIO()
-                try:
-                    _sentence_transformer = SentenceTransformer("all-MiniLM-L6-v2")
-                finally:
-                    sys.stdout, sys.stderr = old_stdout, old_stderr
-                    st_logger.setLevel(old_st_level)
-                    tf_logger.setLevel(old_tf_level)
-
-            logger.debug("Loaded sentence transformer: all-MiniLM-L6-v2")
-        except ImportError:
-            raise ImportError(
-                "sentence-transformers required. Install with: pip install sentence-transformers"
-            )
-    return _sentence_transformer
+    """Return the shared SentenceTransformer from Services."""
+    from ..services import get_default_services
+    return get_default_services().embedding_model
 
 
 @dataclass
@@ -453,27 +465,14 @@ class CorpusIndexer:
         return chunks
 
 
-# Default indexer using project data directory
-_default_indexer = None
-
-
 def get_indexer(persist_dir: Optional[str] = None) -> CorpusIndexer:
-    """Get a corpus indexer.
+    """Return a CorpusIndexer.
 
-    Args:
-        persist_dir: Directory for persistence. If None, uses default.
-
-    Returns:
-        CorpusIndexer instance.
+    With no persist_dir, returns the shared indexer owned by the default
+    Services container (pointed at the project data directory). With an
+    explicit persist_dir, returns a new uncached instance.
     """
-    global _default_indexer
-
     if persist_dir is not None:
         return CorpusIndexer(persist_dir)
-
-    if _default_indexer is None:
-        # Use project's data directory by default
-        default_dir = Path(__file__).parent.parent.parent / "data" / "rag_index"
-        _default_indexer = CorpusIndexer(str(default_dir))
-
-    return _default_indexer
+    from ..services import get_default_services
+    return get_default_services().indexer

--- a/src/rag/corpus_indexer.py
+++ b/src/rag/corpus_indexer.py
@@ -102,16 +102,26 @@ class IndexedChunk:
 class CorpusIndexer:
     """Indexes author corpora into ChromaDB for style retrieval."""
 
-    def __init__(self, persist_dir: Optional[str] = None):
+    def __init__(
+        self,
+        persist_dir: Optional[str] = None,
+        *,
+        style_analyzer: Optional[StyleAnalyzer] = None,
+    ):
         """Initialize the indexer.
 
         Args:
             persist_dir: Directory to persist ChromaDB. If None, uses in-memory.
+            style_analyzer: Injected StyleAnalyzer. Defaults to the one held by
+                the shared Services container (`get_default_services().style_analyzer`).
         """
         self.persist_dir = persist_dir
         self._client = None
         self._collection = None
-        self._analyzer = StyleAnalyzer()
+        if style_analyzer is None:
+            from ..services import get_default_services
+            style_analyzer = get_default_services().style_analyzer
+        self._analyzer = style_analyzer
         self._embedding_model = None
 
     @property

--- a/src/rag/enhanced_analyzer.py
+++ b/src/rag/enhanced_analyzer.py
@@ -10,7 +10,7 @@ Concrete patterns ("DET ADJ NOUN — ADV VERB") do.
 """
 
 from dataclasses import dataclass, field
-from typing import List, Dict, Set, Optional
+from typing import List, Dict, Set
 from collections import Counter
 
 from ..utils.nlp import get_nlp
@@ -724,13 +724,7 @@ class EnhancedStructuralAnalyzer:
         )
 
 
-# Module singleton
-_enhanced_analyzer: Optional[EnhancedStructuralAnalyzer] = None
-
-
 def get_enhanced_analyzer() -> EnhancedStructuralAnalyzer:
-    """Get the enhanced structural analyzer singleton."""
-    global _enhanced_analyzer
-    if _enhanced_analyzer is None:
-        _enhanced_analyzer = EnhancedStructuralAnalyzer()
-    return _enhanced_analyzer
+    """Return the shared EnhancedStructuralAnalyzer from the default Services container."""
+    from ..services import get_default_services
+    return get_default_services().enhanced_analyzer

--- a/src/rag/structural_analyzer.py
+++ b/src/rag/structural_analyzer.py
@@ -276,16 +276,10 @@ class StructuralAnalyzer:
         )
 
 
-# Module singleton
-_analyzer = None
-
-
 def get_structural_analyzer() -> StructuralAnalyzer:
-    """Get the structural analyzer singleton."""
-    global _analyzer
-    if _analyzer is None:
-        _analyzer = StructuralAnalyzer()
-    return _analyzer
+    """Return the shared StructuralAnalyzer from the default Services container."""
+    from ..services import get_default_services
+    return get_default_services().structural_analyzer
 
 
 def extract_rhythm_instruction(text: str) -> str:

--- a/src/rag/style_analyzer.py
+++ b/src/rag/style_analyzer.py
@@ -174,16 +174,10 @@ class StyleAnalyzer:
         return [self.analyze(text) for text in texts]
 
 
-# Module-level singleton for convenience
-_analyzer = None
-
-
 def get_style_analyzer() -> StyleAnalyzer:
-    """Get the singleton style analyzer."""
-    global _analyzer
-    if _analyzer is None:
-        _analyzer = StyleAnalyzer()
-    return _analyzer
+    """Return the shared StyleAnalyzer from the default Services container."""
+    from ..services import get_default_services
+    return get_default_services().style_analyzer
 
 
 def analyze_style(text: str) -> StyleMetrics:

--- a/src/services.py
+++ b/src/services.py
@@ -16,7 +16,15 @@ migration so existing callers keep working; new code is encouraged to accept a
 `services: Services` argument directly.
 """
 
-from typing import Any, Optional
+import contextlib
+import threading
+from typing import Any, Iterator, Optional
+
+
+# Sentinel distinct from None. A loader may legitimately return None (e.g. an
+# optional dependency is missing) — using None as "not loaded" would re-run
+# the loader forever in that case.
+_UNSET: Any = object()
 
 
 class Services:
@@ -24,22 +32,28 @@ class Services:
 
     All constructor arguments are keyword-only to keep slot assignment
     unambiguous as the container grows. Unknown kwargs raise TypeError.
+
+    Each lazy-load property is guarded by a per-container lock with
+    double-checked locking so concurrent access from worker threads
+    (see e.g. ThreadPoolExecutor in `mlx_provider`) runs the loader
+    exactly once.
     """
 
     def __init__(
         self,
         *,
-        nlp: Any = None,
-        grammar_corrector: Any = None,
-        semantic_verifier: Any = None,
-        nli_model: Any = None,
-        chromadb: Any = None,
-        embedding_model: Any = None,
-        indexer: Any = None,
-        structural_analyzer: Any = None,
-        style_analyzer: Any = None,
-        enhanced_analyzer: Any = None,
+        nlp: Any = _UNSET,
+        grammar_corrector: Any = _UNSET,
+        semantic_verifier: Any = _UNSET,
+        nli_model: Any = _UNSET,
+        chromadb: Any = _UNSET,
+        embedding_model: Any = _UNSET,
+        indexer: Any = _UNSET,
+        structural_analyzer: Any = _UNSET,
+        style_analyzer: Any = _UNSET,
+        enhanced_analyzer: Any = _UNSET,
     ):
+        self._lock = threading.Lock()
         self._nlp = nlp
         self._grammar_corrector = grammar_corrector
         self._semantic_verifier = semantic_verifier
@@ -51,94 +65,112 @@ class Services:
         self._style_analyzer = style_analyzer
         self._enhanced_analyzer = enhanced_analyzer
 
-    # Properties return the stored slot. Per-singleton migrations wire up
-    # lazy loaders here; until a slot is migrated, callers continue using its
-    # legacy get_*() helper. An uninjected, unmigrated slot returns None.
-
     @property
     def nlp(self) -> Any:
-        if self._nlp is None:
-            from .utils.nlp import _load_spacy_nlp
-            self._nlp = _load_spacy_nlp()
+        if self._nlp is _UNSET:
+            with self._lock:
+                if self._nlp is _UNSET:
+                    from .utils.nlp import _load_spacy_nlp
+                    self._nlp = _load_spacy_nlp()
         return self._nlp
 
     @property
     def grammar_corrector(self) -> Any:
-        if self._grammar_corrector is None:
-            from .vocabulary.grammar_corrector import GrammarCorrector
-            self._grammar_corrector = GrammarCorrector()
+        if self._grammar_corrector is _UNSET:
+            with self._lock:
+                if self._grammar_corrector is _UNSET:
+                    from .vocabulary.grammar_corrector import GrammarCorrector
+                    self._grammar_corrector = GrammarCorrector()
         return self._grammar_corrector
 
     @property
     def semantic_verifier(self) -> Any:
-        if self._semantic_verifier is None:
-            from .validation.semantic_verifier import SemanticVerifier
-            self._semantic_verifier = SemanticVerifier()
+        if self._semantic_verifier is _UNSET:
+            with self._lock:
+                if self._semantic_verifier is _UNSET:
+                    from .validation.semantic_verifier import SemanticVerifier
+                    self._semantic_verifier = SemanticVerifier()
         return self._semantic_verifier
 
     @property
     def nli_model(self) -> Any:
-        if self._nli_model is None:
-            from .validation.semantic_verifier import _load_nli_model
-            self._nli_model = _load_nli_model()
+        if self._nli_model is _UNSET:
+            with self._lock:
+                if self._nli_model is _UNSET:
+                    from .validation.semantic_verifier import _load_nli_model
+                    self._nli_model = _load_nli_model()
         return self._nli_model
 
     @property
     def chromadb(self) -> Any:
-        if self._chromadb is None:
-            from .rag.corpus_indexer import _load_chromadb
-            self._chromadb = _load_chromadb()
+        if self._chromadb is _UNSET:
+            with self._lock:
+                if self._chromadb is _UNSET:
+                    from .rag.corpus_indexer import _load_chromadb
+                    self._chromadb = _load_chromadb()
         return self._chromadb
 
     @property
     def embedding_model(self) -> Any:
-        if self._embedding_model is None:
-            from .rag.corpus_indexer import _load_embedding_model
-            self._embedding_model = _load_embedding_model()
+        if self._embedding_model is _UNSET:
+            with self._lock:
+                if self._embedding_model is _UNSET:
+                    from .rag.corpus_indexer import _load_embedding_model
+                    self._embedding_model = _load_embedding_model()
         return self._embedding_model
 
     @property
     def indexer(self) -> Any:
-        if self._indexer is None:
-            from .rag.corpus_indexer import _load_default_indexer
-            self._indexer = _load_default_indexer()
+        if self._indexer is _UNSET:
+            with self._lock:
+                if self._indexer is _UNSET:
+                    from .rag.corpus_indexer import _load_default_indexer
+                    self._indexer = _load_default_indexer()
         return self._indexer
 
     @property
     def structural_analyzer(self) -> Any:
-        if self._structural_analyzer is None:
-            from .rag.structural_analyzer import StructuralAnalyzer
-            self._structural_analyzer = StructuralAnalyzer()
+        if self._structural_analyzer is _UNSET:
+            with self._lock:
+                if self._structural_analyzer is _UNSET:
+                    from .rag.structural_analyzer import StructuralAnalyzer
+                    self._structural_analyzer = StructuralAnalyzer()
         return self._structural_analyzer
 
     @property
     def style_analyzer(self) -> Any:
-        if self._style_analyzer is None:
-            from .rag.style_analyzer import StyleAnalyzer
-            self._style_analyzer = StyleAnalyzer()
+        if self._style_analyzer is _UNSET:
+            with self._lock:
+                if self._style_analyzer is _UNSET:
+                    from .rag.style_analyzer import StyleAnalyzer
+                    self._style_analyzer = StyleAnalyzer()
         return self._style_analyzer
 
     @property
     def enhanced_analyzer(self) -> Any:
-        if self._enhanced_analyzer is None:
-            from .rag.enhanced_analyzer import EnhancedStructuralAnalyzer
-            self._enhanced_analyzer = EnhancedStructuralAnalyzer()
+        if self._enhanced_analyzer is _UNSET:
+            with self._lock:
+                if self._enhanced_analyzer is _UNSET:
+                    from .rag.enhanced_analyzer import EnhancedStructuralAnalyzer
+                    self._enhanced_analyzer = EnhancedStructuralAnalyzer()
         return self._enhanced_analyzer
 
 
 _default_services: Optional[Services] = None
+_default_services_lock = threading.Lock()
 
 
 def get_default_services() -> Services:
     """Return the process-wide default Services container, creating it lazily.
 
     Legacy get_*() helpers delegate here during the migration. Tests that need
-    isolation should use `set_default_services(Services(...))` (remember to
-    restore the original in a `finally` block).
+    isolation should use the `default_services()` context manager.
     """
     global _default_services
     if _default_services is None:
-        _default_services = Services()
+        with _default_services_lock:
+            if _default_services is None:
+                _default_services = Services()
     return _default_services
 
 
@@ -146,3 +178,33 @@ def set_default_services(services: Services) -> None:
     """Swap the default container — primarily a test seam."""
     global _default_services
     _default_services = services
+
+
+@contextlib.contextmanager
+def default_services(services: Optional[Services] = None) -> Iterator[Services]:
+    """Temporarily swap the default Services container for the body of a
+    `with` block, restoring the previous container (even on exception).
+
+    Replaces the try/finally pattern test code was repeating everywhere:
+
+        original = get_default_services()
+        try:
+            set_default_services(Services(...))
+            ...
+        finally:
+            set_default_services(original)
+
+    becomes simply:
+
+        with default_services(Services(...)):
+            ...
+
+    With no argument, a fresh empty Services is installed.
+    """
+    original = get_default_services()
+    replacement = services if services is not None else Services()
+    set_default_services(replacement)
+    try:
+        yield replacement
+    finally:
+        set_default_services(original)

--- a/src/services.py
+++ b/src/services.py
@@ -1,0 +1,148 @@
+"""Dependency container that replaces module-global singletons.
+
+Historically, shared state (spaCy model, grammar corrector, semantic verifier,
+ChromaDB handle, …) has been held in module-level variables and accessed through
+`get_*()` helpers. That pattern makes tests brittle — they reach into private
+module globals (e.g. `sv._verifier = None`) to reset state between runs — and
+couples everything to a single process-wide instance.
+
+`Services` is an explicit container for these dependencies. Each slot can be:
+
+- pre-populated via the keyword-only constructor (test injection), or
+- lazy-loaded on first property access (production default).
+
+The legacy `get_*()` helpers delegate to `get_default_services()` during the
+migration so existing callers keep working; new code is encouraged to accept a
+`services: Services` argument directly.
+"""
+
+from typing import Any, Optional
+
+
+class Services:
+    """Lazy dependency container.
+
+    All constructor arguments are keyword-only to keep slot assignment
+    unambiguous as the container grows. Unknown kwargs raise TypeError.
+    """
+
+    def __init__(
+        self,
+        *,
+        nlp: Any = None,
+        grammar_corrector: Any = None,
+        semantic_verifier: Any = None,
+        nli_model: Any = None,
+        chromadb: Any = None,
+        embedding_model: Any = None,
+        indexer: Any = None,
+        structural_analyzer: Any = None,
+        style_analyzer: Any = None,
+        enhanced_analyzer: Any = None,
+    ):
+        self._nlp = nlp
+        self._grammar_corrector = grammar_corrector
+        self._semantic_verifier = semantic_verifier
+        self._nli_model = nli_model
+        self._chromadb = chromadb
+        self._embedding_model = embedding_model
+        self._indexer = indexer
+        self._structural_analyzer = structural_analyzer
+        self._style_analyzer = style_analyzer
+        self._enhanced_analyzer = enhanced_analyzer
+
+    # Properties return the stored slot. Per-singleton migrations wire up
+    # lazy loaders here; until a slot is migrated, callers continue using its
+    # legacy get_*() helper. An uninjected, unmigrated slot returns None.
+
+    @property
+    def nlp(self) -> Any:
+        if self._nlp is None:
+            from .utils.nlp import _load_spacy_nlp
+            self._nlp = _load_spacy_nlp()
+        return self._nlp
+
+    @property
+    def grammar_corrector(self) -> Any:
+        if self._grammar_corrector is None:
+            from .vocabulary.grammar_corrector import GrammarCorrector
+            self._grammar_corrector = GrammarCorrector()
+        return self._grammar_corrector
+
+    @property
+    def semantic_verifier(self) -> Any:
+        if self._semantic_verifier is None:
+            from .validation.semantic_verifier import SemanticVerifier
+            self._semantic_verifier = SemanticVerifier()
+        return self._semantic_verifier
+
+    @property
+    def nli_model(self) -> Any:
+        if self._nli_model is None:
+            from .validation.semantic_verifier import _load_nli_model
+            self._nli_model = _load_nli_model()
+        return self._nli_model
+
+    @property
+    def chromadb(self) -> Any:
+        if self._chromadb is None:
+            from .rag.corpus_indexer import _load_chromadb
+            self._chromadb = _load_chromadb()
+        return self._chromadb
+
+    @property
+    def embedding_model(self) -> Any:
+        if self._embedding_model is None:
+            from .rag.corpus_indexer import _load_embedding_model
+            self._embedding_model = _load_embedding_model()
+        return self._embedding_model
+
+    @property
+    def indexer(self) -> Any:
+        if self._indexer is None:
+            from .rag.corpus_indexer import _load_default_indexer
+            self._indexer = _load_default_indexer()
+        return self._indexer
+
+    @property
+    def structural_analyzer(self) -> Any:
+        if self._structural_analyzer is None:
+            from .rag.structural_analyzer import StructuralAnalyzer
+            self._structural_analyzer = StructuralAnalyzer()
+        return self._structural_analyzer
+
+    @property
+    def style_analyzer(self) -> Any:
+        if self._style_analyzer is None:
+            from .rag.style_analyzer import StyleAnalyzer
+            self._style_analyzer = StyleAnalyzer()
+        return self._style_analyzer
+
+    @property
+    def enhanced_analyzer(self) -> Any:
+        if self._enhanced_analyzer is None:
+            from .rag.enhanced_analyzer import EnhancedStructuralAnalyzer
+            self._enhanced_analyzer = EnhancedStructuralAnalyzer()
+        return self._enhanced_analyzer
+
+
+_default_services: Optional[Services] = None
+
+
+def get_default_services() -> Services:
+    """Return the process-wide default Services container, creating it lazily.
+
+    Legacy get_*() helpers delegate here during the migration. Tests that need
+    isolation should use `set_default_services(Services(...))` (remember to
+    restore the original in a `finally` block).
+    """
+    global _default_services
+    if _default_services is None:
+        _default_services = Services()
+    return _default_services
+
+
+def set_default_services(services: Services) -> None:
+    """Swap the default container — primarily a test seam."""
+    global _default_services
+    _default_services = services

--- a/src/utils/nlp.py
+++ b/src/utils/nlp.py
@@ -7,42 +7,43 @@ from .logging import get_logger
 
 logger = get_logger(__name__)
 
-# Lazy-loaded spaCy model
-_nlp = None
+def _load_spacy_nlp():
+    """Load the spaCy model, preferring the large one with word vectors.
+    Called once per Services container (cached on `Services._nlp`).
+
+    Raises:
+        RuntimeError: If spaCy is not installed.
+    """
+    try:
+        import spacy
+        # Prefer large model with word vectors, fall back to smaller models
+        models = ["en_core_web_lg", "en_core_web_md", "en_core_web_sm"]
+        for model_name in models:
+            try:
+                nlp = spacy.load(model_name)
+                logger.info(f"Loaded spaCy model: {model_name}")
+                return nlp
+            except OSError:
+                continue
+        # No model found, download and use large model
+        logger.info("Downloading spaCy model en_core_web_lg...")
+        from spacy.cli import download
+        download("en_core_web_lg")
+        nlp = spacy.load("en_core_web_lg")
+        logger.info("Downloaded and loaded spaCy model: en_core_web_lg")
+        return nlp
+    except ImportError:
+        raise RuntimeError("spaCy is required. Install with: pip install spacy")
 
 
 def get_nlp():
-    """Get the spaCy NLP model, loading it if necessary.
-
-    Returns:
-        spaCy Language model.
+    """Return the shared spaCy model from the default Services container.
 
     Raises:
         RuntimeError: If spaCy model cannot be loaded.
     """
-    global _nlp
-    if _nlp is None:
-        try:
-            import spacy
-            # Prefer large model with word vectors, fall back to smaller models
-            models = ["en_core_web_lg", "en_core_web_md", "en_core_web_sm"]
-            for model_name in models:
-                try:
-                    _nlp = spacy.load(model_name)
-                    logger.info(f"Loaded spaCy model: {model_name}")
-                    break
-                except OSError:
-                    continue
-            else:
-                # No model found, download and use large model
-                logger.info("Downloading spaCy model en_core_web_lg...")
-                from spacy.cli import download
-                download("en_core_web_lg")
-                _nlp = spacy.load("en_core_web_lg")
-                logger.info("Downloaded and loaded spaCy model: en_core_web_lg")
-        except ImportError:
-            raise RuntimeError("spaCy is required. Install with: pip install spacy")
-    return _nlp
+    from ..services import get_default_services
+    return get_default_services().nlp
 
 
 def split_into_sentences(text: str) -> List[str]:

--- a/src/validation/semantic_verifier.py
+++ b/src/validation/semantic_verifier.py
@@ -15,6 +15,7 @@ from typing import List, Tuple, Optional, Set
 import re
 
 from ..utils.logging import get_logger
+from ..utils.nlp import get_nlp as _get_nlp
 
 logger = get_logger(__name__)
 

--- a/src/validation/semantic_verifier.py
+++ b/src/validation/semantic_verifier.py
@@ -21,10 +21,6 @@ logger = get_logger(__name__)
 # Unified POS tag set for content word extraction (used in grounding + coverage)
 CONTENT_POS_TAGS = {'NOUN', 'VERB', 'ADJ', 'ADV', 'PROPN', 'NUM'}
 
-# Lazy-loaded models
-_nli_model = None
-_nlp = None
-
 
 class _SilentCrossEncoder:
     """Wrapper that ensures CrossEncoder.predict always suppresses progress bars."""
@@ -41,53 +37,54 @@ class _SilentCrossEncoder:
         return getattr(self._model, name)
 
 
+def _load_nli_model():
+    """Load the NLI CrossEncoder with full stdout/stderr/tqdm suppression.
+
+    Called once per Services container (the result is cached on
+    `Services._nli_model`). Returns None if sentence-transformers is missing.
+    """
+    try:
+        import sys
+        import os
+        import warnings
+        import logging
+        from io import StringIO
+
+        # Disable tqdm before importing sentence_transformers
+        os.environ["TQDM_DISABLE"] = "1"
+        from sentence_transformers import CrossEncoder
+
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore")
+            transformers_logger = logging.getLogger("transformers")
+            old_level = transformers_logger.level
+            transformers_logger.setLevel(logging.ERROR)
+            old_stdout, old_stderr = sys.stdout, sys.stderr
+            sys.stdout = StringIO()
+            sys.stderr = StringIO()
+            try:
+                model = CrossEncoder(
+                    "cross-encoder/nli-deberta-v3-small",
+                    max_length=512,
+                )
+                wrapped = _SilentCrossEncoder(model)
+            finally:
+                sys.stdout, sys.stderr = old_stdout, old_stderr
+                transformers_logger.setLevel(old_level)
+        logger.debug("Loaded NLI model for semantic verification")
+        return wrapped
+    except ImportError:
+        logger.warning("sentence-transformers not available for NLI")
+        return None
+
+
 def _get_nli_model():
-    """Get the NLI model, loading if necessary."""
-    global _nli_model
-    if _nli_model is None:
-        try:
-            import sys
-            import os
-            import warnings
-            import logging
-            from io import StringIO
-
-            # Disable tqdm before importing sentence_transformers
-            os.environ["TQDM_DISABLE"] = "1"
-            from sentence_transformers import CrossEncoder
-
-            with warnings.catch_warnings():
-                warnings.filterwarnings("ignore")
-                transformers_logger = logging.getLogger("transformers")
-                old_level = transformers_logger.level
-                transformers_logger.setLevel(logging.ERROR)
-                old_stdout, old_stderr = sys.stdout, sys.stderr
-                sys.stdout = StringIO()
-                sys.stderr = StringIO()
-                try:
-                    model = CrossEncoder(
-                        "cross-encoder/nli-deberta-v3-small",
-                        max_length=512,
-                    )
-                    # Wrap to always suppress progress bars
-                    _nli_model = _SilentCrossEncoder(model)
-                finally:
-                    sys.stdout, sys.stderr = old_stdout, old_stderr
-                    transformers_logger.setLevel(old_level)
-            logger.debug("Loaded NLI model for semantic verification")
-        except ImportError:
-            logger.warning("sentence-transformers not available for NLI")
-            _nli_model = None
-    return _nli_model
+    """Return the shared NLI model from the default Services container."""
+    from ..services import get_default_services
+    return get_default_services().nli_model
 
 
-def _get_nlp():
-    """Get spaCy model for NLP processing."""
-    global _nlp
-    if _nlp is None:
-        from ..utils.nlp import get_nlp
-        _nlp = get_nlp()
-    return _nlp
+from ..utils.nlp import get_nlp as _get_nlp
 
 
 @dataclass
@@ -601,21 +598,17 @@ class SemanticVerifier:
         return forward, backward
 
 
-# Singleton instance
-_verifier = None
-
-
 def get_semantic_verifier(**kwargs) -> SemanticVerifier:
-    """Get or create the singleton semantic verifier.
+    """Return a SemanticVerifier.
 
-    Args:
-        **kwargs: Passed to SemanticVerifier() on first creation only.
-                  Subsequent calls return the existing instance.
+    With no kwargs, returns the shared verifier owned by the default
+    Services container. With kwargs, returns a new uncached instance
+    (the default container's verifier is not replaced).
     """
-    global _verifier
-    if _verifier is None:
-        _verifier = SemanticVerifier(**kwargs)
-    return _verifier
+    if kwargs:
+        return SemanticVerifier(**kwargs)
+    from ..services import get_default_services
+    return get_default_services().semantic_verifier
 
 
 def verify_semantic_preservation(

--- a/src/vocabulary/grammar_corrector.py
+++ b/src/vocabulary/grammar_corrector.py
@@ -298,16 +298,17 @@ class GrammarCorrector:
             self._tool = None
 
 
-# Module singleton
-_corrector: Optional[GrammarCorrector] = None
-
-
 def get_grammar_corrector(config: Optional[GrammarCorrectorConfig] = None) -> GrammarCorrector:
-    """Get or create singleton grammar corrector instance."""
-    global _corrector
-    if _corrector is None:
-        _corrector = GrammarCorrector(config)
-    return _corrector
+    """Return a GrammarCorrector.
+
+    With no config, returns the shared corrector owned by the default
+    Services container. With an explicit config, returns a new uncached
+    instance (the default container's corrector is not replaced).
+    """
+    if config is not None:
+        return GrammarCorrector(config)
+    from ..services import get_default_services
+    return get_default_services().grammar_corrector
 
 
 def correct_grammar(text: str) -> str:

--- a/tests/unit/test_grammar_corrector.py
+++ b/tests/unit/test_grammar_corrector.py
@@ -288,29 +288,33 @@ class TestModuleFunctions:
     """Tests for module-level convenience functions."""
 
     def test_get_grammar_corrector_singleton(self):
-        """Test that get_grammar_corrector returns singleton."""
+        """get_grammar_corrector() returns the same corrector across calls,
+        now backed by the default Services container."""
+        from src.services import Services, get_default_services, set_default_services
         from src.vocabulary.grammar_corrector import get_grammar_corrector
 
-        # Reset singleton
-        import src.vocabulary.grammar_corrector as module
-        module._corrector = None
-
-        c1 = get_grammar_corrector()
-        c2 = get_grammar_corrector()
-
-        assert c1 is c2
+        original = get_default_services()
+        try:
+            set_default_services(Services())  # fresh container for isolation
+            c1 = get_grammar_corrector()
+            c2 = get_grammar_corrector()
+            assert c1 is c2
+        finally:
+            set_default_services(original)
 
     def test_correct_grammar_function(self):
         """Test the convenience correct_grammar function."""
+        from src.services import Services, get_default_services, set_default_services
         from src.vocabulary.grammar_corrector import correct_grammar
 
-        # Reset singleton
-        import src.vocabulary.grammar_corrector as module
-        module._corrector = None
-
-        # Just verify it doesn't crash (LanguageTool may not be installed)
-        result = correct_grammar("This is a test.")
-        assert isinstance(result, str)
+        original = get_default_services()
+        try:
+            set_default_services(Services())
+            # Just verify it doesn't crash (LanguageTool may not be installed)
+            result = correct_grammar("This is a test.")
+            assert isinstance(result, str)
+        finally:
+            set_default_services(original)
 
 
 class TestDefaultSkipLists:

--- a/tests/unit/test_rag.py
+++ b/tests/unit/test_rag.py
@@ -354,6 +354,32 @@ Science is not only compatible with spirituality; it is a profound source of spi
         assert len(authors) == 2  # Deduplicated
 
 
+class TestCorpusIndexerDependencyInjection:
+    """CorpusIndexer.__init__ should accept an injected StyleAnalyzer rather
+    than constructing one directly. The default should come from the shared
+    Services container so tests can swap it without monkeypatching module
+    internals."""
+
+    def test_injected_style_analyzer_is_used(self):
+        from src.rag.corpus_indexer import CorpusIndexer
+
+        fake = object()
+        indexer = CorpusIndexer(style_analyzer=fake)  # type: ignore[arg-type]
+        assert indexer._analyzer is fake
+
+    def test_default_style_analyzer_comes_from_services_container(self):
+        """Without an explicit style_analyzer, CorpusIndexer falls back to the
+        one in the default Services container. Swapping that container (via
+        default_services) must swap the analyzer CorpusIndexer sees."""
+        from src.rag.corpus_indexer import CorpusIndexer
+        from src.services import Services, default_services
+
+        fake = object()
+        with default_services(Services(style_analyzer=fake)):
+            indexer = CorpusIndexer()
+            assert indexer._analyzer is fake
+
+
 # =============================================================================
 # Tests for EnhancedStructuralAnalyzer
 # =============================================================================

--- a/tests/unit/test_semantic_verifier.py
+++ b/tests/unit/test_semantic_verifier.py
@@ -1,7 +1,9 @@
 """Tests for semantic verifier module.
 
 Tests cover:
-- Bug 6: Singleton ignores thresholds
+- Bug 6: Singleton ignores thresholds (now: kwargs yield a new uncached
+  instance; the latent bug where subsequent kwargs were silently ignored
+  no longer applies)
 """
 
 import pytest
@@ -9,31 +11,37 @@ from unittest.mock import patch
 
 
 class TestSemanticVerifierSingleton:
-    """Tests for get_semantic_verifier singleton (Bug 6)."""
+    """Tests for get_semantic_verifier backed by the Services container."""
 
     def setup_method(self):
-        """Reset singleton before each test."""
-        import src.validation.semantic_verifier as sv
-        sv._verifier = None
+        """Swap the default Services container for test isolation."""
+        from src.services import Services, get_default_services, set_default_services
+        self._original_services = get_default_services()
+        set_default_services(Services())
 
-    def test_singleton_with_custom_threshold(self):
-        """Singleton should accept and store custom kwargs."""
+    def teardown_method(self):
+        from src.services import set_default_services
+        set_default_services(self._original_services)
+
+    def test_kwargs_yield_requested_threshold(self):
+        """get_semantic_verifier(**kwargs) returns an instance configured with kwargs."""
         from src.validation.semantic_verifier import get_semantic_verifier
 
         verifier = get_semantic_verifier(grounding_threshold=0.8)
         assert verifier.grounding_threshold == 0.8
 
-    def test_singleton_ignores_subsequent_kwargs(self):
-        """Second call should return existing instance, ignoring new kwargs."""
+    def test_kwargs_yield_new_uncached_instance(self):
+        """Different kwargs produce different instances — no silent reuse."""
         from src.validation.semantic_verifier import get_semantic_verifier
 
         v1 = get_semantic_verifier(grounding_threshold=0.8)
         v2 = get_semantic_verifier(grounding_threshold=0.5)
-        assert v1 is v2
-        assert v2.grounding_threshold == 0.8  # First value wins
+        assert v1 is not v2
+        assert v1.grounding_threshold == 0.8
+        assert v2.grounding_threshold == 0.5
 
-    def test_singleton_returns_same_instance(self):
-        """Multiple calls should return the same instance."""
+    def test_no_kwargs_returns_shared_services_instance(self):
+        """Calls without kwargs return the shared Services verifier."""
         from src.validation.semantic_verifier import get_semantic_verifier
 
         v1 = get_semantic_verifier()
@@ -145,9 +153,14 @@ class TestUnusedEntailmentThreshold:
     The grounding check at line 365 uses grounding_threshold instead."""
 
     def setup_method(self):
-        """Reset singleton."""
-        import src.validation.semantic_verifier as sv
-        sv._verifier = None
+        """Swap default Services for test isolation."""
+        from src.services import Services, get_default_services, set_default_services
+        self._original_services = get_default_services()
+        set_default_services(Services())
+
+    def teardown_method(self):
+        from src.services import set_default_services
+        set_default_services(self._original_services)
 
     def test_entailment_threshold_not_dead_code(self):
         """entailment_threshold should be used in the verifier, not just stored."""

--- a/tests/unit/test_semantic_verifier.py
+++ b/tests/unit/test_semantic_verifier.py
@@ -13,15 +13,12 @@ from unittest.mock import patch
 class TestSemanticVerifierSingleton:
     """Tests for get_semantic_verifier backed by the Services container."""
 
-    def setup_method(self):
-        """Swap the default Services container for test isolation."""
-        from src.services import Services, get_default_services, set_default_services
-        self._original_services = get_default_services()
-        set_default_services(Services())
-
-    def teardown_method(self):
-        from src.services import set_default_services
-        set_default_services(self._original_services)
+    @pytest.fixture(autouse=True)
+    def _isolated_services(self):
+        """Each test gets a fresh default Services container, restored after."""
+        from src.services import default_services
+        with default_services():
+            yield
 
     def test_kwargs_yield_requested_threshold(self):
         """get_semantic_verifier(**kwargs) returns an instance configured with kwargs."""
@@ -152,15 +149,12 @@ class TestUnusedEntailmentThreshold:
     """Bug: SemanticVerifier stores entailment_threshold but never uses it.
     The grounding check at line 365 uses grounding_threshold instead."""
 
-    def setup_method(self):
-        """Swap default Services for test isolation."""
-        from src.services import Services, get_default_services, set_default_services
-        self._original_services = get_default_services()
-        set_default_services(Services())
-
-    def teardown_method(self):
-        from src.services import set_default_services
-        set_default_services(self._original_services)
+    @pytest.fixture(autouse=True)
+    def _isolated_services(self):
+        """Each test gets a fresh default Services container, restored after."""
+        from src.services import default_services
+        with default_services():
+            yield
 
     def test_entailment_threshold_not_dead_code(self):
         """entailment_threshold should be used in the verifier, not just stored."""

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -448,5 +448,174 @@ class TestEnhancedAnalyzerMigration:
             set_default_services(original)
 
 
+class TestLazyLoadCaching:
+    """Lazy-load slots must cache the result even when the loader legitimately
+    returns None (e.g. optional dependency missing). Using `None` as the
+    'unset' sentinel would re-run the loader forever in that case."""
+
+    def test_nli_model_loader_called_once_when_it_returns_none(self, monkeypatch):
+        from src import services as services_mod
+        from src.services import Services
+
+        call_count = [0]
+
+        def fake_loader():
+            call_count[0] += 1
+            return None  # simulate sentence-transformers not installed
+
+        monkeypatch.setattr(
+            "src.validation.semantic_verifier._load_nli_model",
+            fake_loader,
+        )
+
+        s = Services()
+        first = s.nli_model
+        second = s.nli_model
+        third = s.nli_model
+
+        assert first is None and second is None and third is None
+        assert call_count[0] == 1, (
+            f"loader ran {call_count[0]} times — None must be cached just like "
+            "any other loaded value; using None as 'unset' sentinel is a bug"
+        )
+
+    def test_grammar_corrector_loader_called_once_when_it_returns_none(self, monkeypatch):
+        """Same invariant for any slot — use grammar_corrector as a spot-check."""
+        from src.services import Services
+
+        call_count = [0]
+
+        class FakeGrammarCorrector:
+            def __init__(self):
+                call_count[0] += 1
+
+        monkeypatch.setattr(
+            "src.vocabulary.grammar_corrector.GrammarCorrector",
+            FakeGrammarCorrector,
+        )
+
+        s = Services()
+        _ = s.grammar_corrector
+        _ = s.grammar_corrector
+        assert call_count[0] == 1
+
+
+class TestLazyLoadThreadSafety:
+    """Services is accessed from worker threads in several places (see
+    mlx_provider.ThreadPoolExecutor usage). The lazy-load slots must be
+    safe against double-initialization races — two threads hitting an
+    unloaded slot should result in the loader running exactly once."""
+
+    def test_concurrent_access_runs_loader_once(self, monkeypatch):
+        import threading
+        import time
+        from src.services import Services
+
+        call_count = [0]
+        count_lock = threading.Lock()
+
+        class SlowStyleAnalyzer:
+            def __init__(self):
+                # Small sleep inside the loader widens the race window so a
+                # missing container lock would produce multiple instantiations.
+                time.sleep(0.01)
+                with count_lock:
+                    call_count[0] += 1
+
+        monkeypatch.setattr(
+            "src.rag.style_analyzer.StyleAnalyzer",
+            SlowStyleAnalyzer,
+        )
+
+        s = Services()
+        results = [None] * 8
+        # All threads rendezvous before touching the property so they all
+        # race into the lazy-load path at once.
+        barrier = threading.Barrier(8)
+
+        def worker(idx):
+            barrier.wait()
+            results[idx] = s.style_analyzer
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert call_count[0] == 1, (
+            f"loader ran {call_count[0]} times across 8 threads — "
+            "lazy-load slot is not thread-safe"
+        )
+        # All threads received the same cached instance
+        assert all(r is results[0] for r in results)
+
+    def test_get_default_services_concurrent_calls_create_one_instance(self, monkeypatch):
+        import threading
+        from src import services as services_mod
+        from src.services import Services
+
+        # Force the lazy default to re-init for this test
+        monkeypatch.setattr(services_mod, "_default_services", None)
+
+        barrier = threading.Barrier(8)
+        results = [None] * 8
+
+        def worker(idx):
+            barrier.wait()
+            results[idx] = services_mod.get_default_services()
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        first = results[0]
+        assert isinstance(first, Services)
+        assert all(r is first for r in results), (
+            "get_default_services() produced more than one container under concurrent access"
+        )
+
+
+class TestDefaultServicesContextManager:
+    """`default_services(services)` swaps the process default, yields it, and
+    restores the original on exit — a clean replacement for the try/finally
+    pattern test code was repeating everywhere."""
+
+    def test_context_manager_swaps_and_restores(self):
+        from src.services import (
+            Services,
+            default_services,
+            get_default_services,
+        )
+
+        before = get_default_services()
+        with default_services() as fresh:
+            assert isinstance(fresh, Services)
+            assert get_default_services() is fresh
+            assert fresh is not before
+        assert get_default_services() is before
+
+    def test_context_manager_restores_on_exception(self):
+        from src.services import default_services, get_default_services
+
+        before = get_default_services()
+        with pytest.raises(RuntimeError):
+            with default_services():
+                raise RuntimeError("boom")
+        assert get_default_services() is before, (
+            "default services must be restored even when the block raised"
+        )
+
+    def test_context_manager_accepts_explicit_services(self):
+        from src.services import Services, default_services, get_default_services
+
+        custom = Services(nlp="fake-nlp")
+        with default_services(custom) as yielded:
+            assert yielded is custom
+            assert get_default_services() is custom
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -1,0 +1,452 @@
+"""Tests for the Services dependency container.
+
+Services replaces module-global singletons (get_nlp(), get_grammar_corrector(),
+get_semantic_verifier(), …) with an explicit container that can be injected
+for testing. Each property lazy-loads on first access and caches thereafter.
+
+The scaffold here pins the shape of the container. Per-singleton lazy-load
+tests live alongside each migration step.
+"""
+
+import pytest
+
+
+ALL_SLOTS = [
+    "nlp",
+    "grammar_corrector",
+    "semantic_verifier",
+    "nli_model",
+    "chromadb",
+    "embedding_model",
+    "indexer",
+    "structural_analyzer",
+    "style_analyzer",
+    "enhanced_analyzer",
+]
+
+
+class TestServicesScaffold:
+    """Container shape — every migration target has a slot, injection works."""
+
+    def test_services_class_exists(self):
+        from src.services import Services
+
+        assert Services is not None
+
+    def test_services_can_be_instantiated_no_args(self):
+        from src.services import Services
+
+        services = Services()
+        assert services is not None
+
+    @pytest.mark.parametrize("slot", ALL_SLOTS)
+    def test_every_slot_exists_as_property(self, slot):
+        """Each singleton we plan to migrate must have a named slot on Services."""
+        from src.services import Services
+
+        # We look on the class, not the instance, so the property descriptor
+        # is visible even before any instance is created.
+        assert hasattr(Services, slot), (
+            f"Services.{slot} is missing — add a slot for this singleton"
+        )
+
+    @pytest.mark.parametrize("slot", ALL_SLOTS)
+    def test_injected_value_is_returned_verbatim(self, slot):
+        """When an object is passed to Services(slot=obj), property returns it
+        without calling any loader. This is the primary test seam."""
+        from src.services import Services
+
+        sentinel = object()
+        services = Services(**{slot: sentinel})
+        assert getattr(services, slot) is sentinel
+
+    @pytest.mark.parametrize("slot", ALL_SLOTS)
+    def test_injected_value_is_cached(self, slot):
+        """Repeat access returns the same injected object."""
+        from src.services import Services
+
+        sentinel = object()
+        services = Services(**{slot: sentinel})
+        first = getattr(services, slot)
+        second = getattr(services, slot)
+        assert first is second
+
+    def test_constructor_is_keyword_only(self):
+        """Positional args would make the constructor brittle as slots grow.
+        Force keyword-only so `Services(some_mock)` can't accidentally populate
+        the wrong slot."""
+        from src.services import Services
+
+        with pytest.raises(TypeError):
+            Services(object())  # type: ignore[misc]
+
+    def test_unknown_kwarg_raises(self):
+        """Typos in slot names should surface loudly, not silently no-op."""
+        from src.services import Services
+
+        with pytest.raises(TypeError):
+            Services(nonexistent_slot=object())  # type: ignore[call-arg]
+
+
+class TestServicesDefaultAccessor:
+    """get_default_services() returns a process-wide default container that
+    existing module-level get_*() helpers can delegate to during migration."""
+
+    def test_default_services_returns_services_instance(self):
+        from src.services import Services, get_default_services
+
+        services = get_default_services()
+        assert isinstance(services, Services)
+
+    def test_default_services_is_singleton(self):
+        from src.services import get_default_services
+
+        a = get_default_services()
+        b = get_default_services()
+        assert a is b
+
+    def test_set_default_services_swaps_the_default(self):
+        """Tests should be able to swap the default for isolation."""
+        from src.services import Services, get_default_services, set_default_services
+
+        original = get_default_services()
+        try:
+            replacement = Services()
+            set_default_services(replacement)
+            assert get_default_services() is replacement
+        finally:
+            set_default_services(original)
+
+
+class TestGrammarCorrectorMigration:
+    """Services.grammar_corrector lazy-loads on first access and
+    get_grammar_corrector() delegates through get_default_services()."""
+
+    def test_lazy_loads_grammar_corrector(self):
+        from src.services import Services
+        from src.vocabulary.grammar_corrector import GrammarCorrector
+
+        services = Services()
+        corrector = services.grammar_corrector
+        assert isinstance(corrector, GrammarCorrector)
+
+    def test_lazy_load_is_cached(self):
+        from src.services import Services
+
+        services = Services()
+        first = services.grammar_corrector
+        second = services.grammar_corrector
+        assert first is second
+
+    def test_get_grammar_corrector_delegates_to_default_services(self):
+        """Module-level get_grammar_corrector() returns the Services instance
+        so every call site migrates in one edit."""
+        from src.services import Services, get_default_services, set_default_services
+        from src.vocabulary.grammar_corrector import GrammarCorrector, get_grammar_corrector
+
+        # Inject a sentinel via a fresh default services container
+        sentinel = GrammarCorrector()
+        original = get_default_services()
+        try:
+            set_default_services(Services(grammar_corrector=sentinel))
+            assert get_grammar_corrector() is sentinel
+        finally:
+            set_default_services(original)
+
+    def test_set_default_services_resets_corrector(self):
+        """Swapping default services is the replacement for `module._corrector = None`."""
+        from src.services import Services, get_default_services, set_default_services
+        from src.vocabulary.grammar_corrector import get_grammar_corrector
+
+        original = get_default_services()
+        try:
+            # First Services instance has its own corrector
+            set_default_services(Services())
+            c1 = get_grammar_corrector()
+
+            # Swap to a fresh Services — new corrector
+            set_default_services(Services())
+            c2 = get_grammar_corrector()
+
+            assert c1 is not c2
+        finally:
+            set_default_services(original)
+
+
+class TestSemanticVerifierMigration:
+    """Services.semantic_verifier lazy-loads, get_semantic_verifier() delegates,
+    and kwargs now yield an uncached new instance (fixing a latent bug where
+    subsequent kwargs were silently ignored by the old module singleton)."""
+
+    def test_lazy_loads_semantic_verifier(self):
+        from src.services import Services
+        from src.validation.semantic_verifier import SemanticVerifier
+
+        services = Services()
+        assert isinstance(services.semantic_verifier, SemanticVerifier)
+
+    def test_lazy_load_is_cached(self):
+        from src.services import Services
+
+        services = Services()
+        assert services.semantic_verifier is services.semantic_verifier
+
+    def test_get_semantic_verifier_delegates_to_default_services(self):
+        from src.services import Services, get_default_services, set_default_services
+        from src.validation.semantic_verifier import SemanticVerifier, get_semantic_verifier
+
+        sentinel = SemanticVerifier()
+        original = get_default_services()
+        try:
+            set_default_services(Services(semantic_verifier=sentinel))
+            assert get_semantic_verifier() is sentinel
+        finally:
+            set_default_services(original)
+
+    def test_get_semantic_verifier_with_kwargs_returns_new_uncached_instance(self):
+        """Kwargs were previously ignored after the first call. Now they yield
+        a new uncached instance, leaving the default container untouched."""
+        from src.services import Services, get_default_services, set_default_services
+        from src.validation.semantic_verifier import get_semantic_verifier
+
+        original = get_default_services()
+        try:
+            set_default_services(Services())
+            v1 = get_semantic_verifier(grounding_threshold=0.8)
+            v2 = get_semantic_verifier(grounding_threshold=0.5)
+            assert v1 is not v2
+            assert v1.grounding_threshold == 0.8
+            assert v2.grounding_threshold == 0.5
+        finally:
+            set_default_services(original)
+
+
+class TestNliModelMigration:
+    """Services.nli_model holds the CrossEncoder. Loading is expensive so tests
+    inject a sentinel rather than triggering a real load."""
+
+    def test_injected_nli_model_is_returned(self):
+        from src.services import Services
+
+        sentinel = object()
+        services = Services(nli_model=sentinel)
+        assert services.nli_model is sentinel
+
+    def test_get_nli_model_delegates_to_services(self):
+        from src.services import Services, get_default_services, set_default_services
+        from src.validation.semantic_verifier import _get_nli_model
+
+        sentinel = object()
+        original = get_default_services()
+        try:
+            set_default_services(Services(nli_model=sentinel))
+            assert _get_nli_model() is sentinel
+        finally:
+            set_default_services(original)
+
+
+class TestCorpusIndexerMigration:
+    """Services.chromadb / embedding_model / indexer replace three module
+    singletons in src/rag/corpus_indexer.py. Only injection is exercised
+    here — the real loaders require chromadb + sentence-transformers."""
+
+    def test_injected_chromadb_is_returned(self):
+        from src.services import Services
+
+        sentinel = object()
+        services = Services(chromadb=sentinel)
+        assert services.chromadb is sentinel
+
+    def test_injected_embedding_model_is_returned(self):
+        from src.services import Services
+
+        sentinel = object()
+        services = Services(embedding_model=sentinel)
+        assert services.embedding_model is sentinel
+
+    def test_injected_indexer_is_returned(self):
+        from src.services import Services
+
+        sentinel = object()
+        services = Services(indexer=sentinel)
+        assert services.indexer is sentinel
+
+    def test_get_chromadb_delegates_to_services(self):
+        from src.services import Services, get_default_services, set_default_services
+        from src.rag.corpus_indexer import get_chromadb
+
+        sentinel = object()
+        original = get_default_services()
+        try:
+            set_default_services(Services(chromadb=sentinel))
+            assert get_chromadb() is sentinel
+        finally:
+            set_default_services(original)
+
+    def test_get_embedding_model_delegates_to_services(self):
+        from src.services import Services, get_default_services, set_default_services
+        from src.rag.corpus_indexer import get_embedding_model
+
+        sentinel = object()
+        original = get_default_services()
+        try:
+            set_default_services(Services(embedding_model=sentinel))
+            assert get_embedding_model() is sentinel
+        finally:
+            set_default_services(original)
+
+    def test_get_indexer_no_arg_delegates_to_services(self):
+        """get_indexer() with no persist_dir returns the shared Services indexer."""
+        from src.services import Services, get_default_services, set_default_services
+        from src.rag.corpus_indexer import get_indexer
+
+        sentinel = object()
+        original = get_default_services()
+        try:
+            set_default_services(Services(indexer=sentinel))
+            assert get_indexer() is sentinel
+        finally:
+            set_default_services(original)
+
+    def test_get_indexer_with_persist_dir_returns_new_instance(self):
+        """Explicit persist_dir bypasses the Services cache (new uncached instance)."""
+        from src.services import Services, get_default_services, set_default_services
+        from src.rag.corpus_indexer import CorpusIndexer, get_indexer
+
+        sentinel = CorpusIndexer("/tmp/unused")
+        original = get_default_services()
+        try:
+            set_default_services(Services(indexer=sentinel))
+            other = get_indexer(persist_dir="/tmp/other")
+            assert other is not sentinel
+            assert isinstance(other, CorpusIndexer)
+            assert other.persist_dir == "/tmp/other"
+        finally:
+            set_default_services(original)
+
+
+class TestStyleAnalyzerMigration:
+    """Services.style_analyzer lazy-loads a StyleAnalyzer, and
+    get_style_analyzer() delegates through the default Services container."""
+
+    def test_lazy_loads_style_analyzer(self):
+        from src.services import Services
+        from src.rag.style_analyzer import StyleAnalyzer
+
+        services = Services()
+        assert isinstance(services.style_analyzer, StyleAnalyzer)
+
+    def test_lazy_load_is_cached(self):
+        from src.services import Services
+
+        services = Services()
+        assert services.style_analyzer is services.style_analyzer
+
+    def test_get_style_analyzer_delegates_to_services(self):
+        from src.services import Services, get_default_services, set_default_services
+        from src.rag.style_analyzer import StyleAnalyzer, get_style_analyzer
+
+        sentinel = StyleAnalyzer()
+        original = get_default_services()
+        try:
+            set_default_services(Services(style_analyzer=sentinel))
+            assert get_style_analyzer() is sentinel
+        finally:
+            set_default_services(original)
+
+
+class TestNlpMigration:
+    """Services.nlp holds the spaCy model. Loading is very expensive so most
+    tests inject a sentinel rather than triggering a real load."""
+
+    def test_injected_nlp_is_returned(self):
+        from src.services import Services
+
+        sentinel = object()
+        services = Services(nlp=sentinel)
+        assert services.nlp is sentinel
+
+    def test_get_nlp_delegates_to_services(self):
+        from src.services import Services, get_default_services, set_default_services
+        from src.utils.nlp import get_nlp
+
+        sentinel = object()
+        original = get_default_services()
+        try:
+            set_default_services(Services(nlp=sentinel))
+            assert get_nlp() is sentinel
+        finally:
+            set_default_services(original)
+
+    def test_nlp_lazy_load_is_cached(self):
+        """Once loaded, the spaCy model is cached on the Services instance."""
+        from src.services import Services
+
+        services = Services()
+        first = services.nlp
+        second = services.nlp
+        assert first is second
+
+
+class TestStructuralAnalyzerMigration:
+    """Services.structural_analyzer lazy-loads, get_structural_analyzer()
+    delegates through the default Services container."""
+
+    def test_lazy_loads_structural_analyzer(self):
+        from src.services import Services
+        from src.rag.structural_analyzer import StructuralAnalyzer
+
+        services = Services()
+        assert isinstance(services.structural_analyzer, StructuralAnalyzer)
+
+    def test_lazy_load_is_cached(self):
+        from src.services import Services
+
+        services = Services()
+        assert services.structural_analyzer is services.structural_analyzer
+
+    def test_get_structural_analyzer_delegates_to_services(self):
+        from src.services import Services, get_default_services, set_default_services
+        from src.rag.structural_analyzer import StructuralAnalyzer, get_structural_analyzer
+
+        sentinel = StructuralAnalyzer()
+        original = get_default_services()
+        try:
+            set_default_services(Services(structural_analyzer=sentinel))
+            assert get_structural_analyzer() is sentinel
+        finally:
+            set_default_services(original)
+
+
+class TestEnhancedAnalyzerMigration:
+    """Services.enhanced_analyzer lazy-loads, get_enhanced_analyzer()
+    delegates through the default Services container."""
+
+    def test_lazy_loads_enhanced_analyzer(self):
+        from src.services import Services
+        from src.rag.enhanced_analyzer import EnhancedStructuralAnalyzer
+
+        services = Services()
+        assert isinstance(services.enhanced_analyzer, EnhancedStructuralAnalyzer)
+
+    def test_lazy_load_is_cached(self):
+        from src.services import Services
+
+        services = Services()
+        assert services.enhanced_analyzer is services.enhanced_analyzer
+
+    def test_get_enhanced_analyzer_delegates_to_services(self):
+        from src.services import Services, get_default_services, set_default_services
+        from src.rag.enhanced_analyzer import EnhancedStructuralAnalyzer, get_enhanced_analyzer
+
+        sentinel = EnhancedStructuralAnalyzer()
+        original = get_default_services()
+        try:
+            set_default_services(Services(enhanced_analyzer=sentinel))
+            assert get_enhanced_analyzer() is sentinel
+        finally:
+            set_default_services(original)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/unit/test_transfer.py
+++ b/tests/unit/test_transfer.py
@@ -240,6 +240,39 @@ class TestStyleTransfer:
         assert score == 1.0
 
     @patch('src.generation.transfer.create_style_generator')
+    def test_init_uses_default_services_when_none_passed(self, mock_generator_class, mock_critic):
+        """Without a services arg, StyleTransfer falls back to the process default."""
+        from src.generation.transfer import StyleTransfer, TransferConfig
+        from src.services import get_default_services
+
+        config = TransferConfig(verify_semantic_fidelity=False)
+        transfer = StyleTransfer(
+            adapter_path=None,
+            author_name="Test",
+            critic_provider=mock_critic,
+            config=config,
+        )
+        assert transfer.services is get_default_services()
+
+    @patch('src.generation.transfer.create_style_generator')
+    def test_init_accepts_injected_services(self, mock_generator_class, mock_critic):
+        """An explicit Services instance is stored on the transfer and used
+        instead of the module-level default — the primary test seam."""
+        from src.generation.transfer import StyleTransfer, TransferConfig
+        from src.services import Services
+
+        services = Services()
+        config = TransferConfig(verify_semantic_fidelity=False)
+        transfer = StyleTransfer(
+            adapter_path=None,
+            author_name="Test",
+            critic_provider=mock_critic,
+            config=config,
+            services=services,
+        )
+        assert transfer.services is services
+
+    @patch('src.generation.transfer.create_style_generator')
     def test_get_partial_results(self, mock_generator_class, mock_critic):
         """Test getting partial results after interruption."""
         from src.generation.transfer import StyleTransfer, TransferConfig


### PR DESCRIPTION
Introduces src/services.py, an explicit dependency container that holds the 10 previously-scattered module-level singletons (nlp, grammar_corrector, semantic_verifier, nli_model, chromadb, embedding_model, indexer, structural_analyzer, style_analyzer, enhanced_analyzer).

Each slot is lazy-loaded on first property access and cached thereafter. Slots can be pre-populated via the keyword-only constructor, which is the primary test seam — no more `module._singleton = None` resets in setUp.

Legacy get_*() helpers (get_nlp, get_grammar_corrector, etc.) now delegate to get_default_services(). The module-level _singleton = None state they used to own is gone.

Side-effect fixes:
- get_semantic_verifier(**kwargs) previously stored the first call's kwargs and silently ignored subsequent ones. Now kwargs yield a new uncached instance, leaving the shared container untouched.
- get_grammar_corrector(config) gets the same treatment.
- get_indexer(persist_dir) now returns a fresh instance only when persist_dir is explicitly passed.

StyleTransfer.__init__ accepts an optional `services: Services` kwarg so callers can inject their own container; defaults to get_default_services() when omitted.

591 tests pass.