### PR TITLE
feat(lora): per-character logit bias via adapter config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,12 @@ atlas_cache/
 lora_adapters/
 models/
 
+# Agent instruction files (local-only)
+CLAUDE.md
+AGENTS.md
+.claude/
+.wolf/
+
 # Logs
 logs/*.md
 !logs/.gitkeep

--- a/README.md
+++ b/README.md
@@ -176,7 +176,8 @@ Key settings in `config.json`:
         "enabled": true,
         "scale": 2.0,
         "temperature": 0.7,
-        "worldview": "russell_worldview.txt"
+        "worldview": "russell_worldview.txt",
+        "logit_bias": { ";": 1.0, "—": 1.5 }
       }
     }
   }
@@ -190,6 +191,8 @@ Key settings in `config.json`:
 | `worldview` | Persona prompt file in `prompts/` (must match training frames exactly) |
 | `apply_input_perturbation` | Add 8% noise to match training distribution |
 | `expand_for_texture` | Pre-expand content for longer output |
+| `logit_bias` | Per-character additive bias (e.g., nudge em-dashes/semicolons without raising rep_penalty) |
+| `use_structural_rag` | Per-adapter override for the global RAG flag |
 
 ## Troubleshooting
 

--- a/config.json.sample
+++ b/config.json.sample
@@ -80,7 +80,12 @@
         "worldview": "lovecraft_worldview.txt",
         "checkpoint": "checkpoint-600",
         "_comment_rag": "use_structural_rag: per-adapter override for generation.use_structural_rag (omit to inherit global)",
-        "use_structural_rag": true
+        "use_structural_rag": true,
+        "_comment_bias": "logit_bias: additive bias per character/string applied to that token's logit every step. Positive values encourage the token, negative suppress. Typical range -5.0 to +5.0. Useful for nudging characteristic punctuation (em-dash, semicolon) without fighting repetition_penalty.",
+        "logit_bias": {
+          ";": 1.0,
+          "—": 1.5
+        }
       },
       "lora_adapters/lovecraft_14b": {
         "_comment": "Qwen2.5-14B local MLX training",

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -650,6 +650,19 @@ Output: "The physicist Einstein[^1] formulated his theory of relativity[^2]."
 }
 ```
 
+Several of these settings can be overridden per-adapter (or per-fused-model) by setting them on the adapter entry. Omit to inherit the global value. Overridable fields:
+
+| Field | Purpose |
+|---|---|
+| `expand_for_texture` | Pre-expand via critic before RTT |
+| `perspective` | Output POV |
+| `verify_entailment` | NLI fidelity check |
+| `merge_paragraphs` | Merge N paragraphs before LoRA |
+| `use_structural_rag` | Pull rhythm patterns from corpus |
+| `logit_bias` | Map of character/string → additive logit bias (e.g., `{";": 1.0, "—": 1.5}`) |
+
+`logit_bias` resolves each key to token IDs via the tokenizer (both bare and leading-space BPE variants) and adds the value to those logits at every sampling step. Use it to nudge characteristic punctuation without raising `repetition_penalty` (which flattens repetition globally).
+
 ---
 
 ## Module Reference

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -69,15 +69,50 @@ Generation parameters are in `config.json` under `lora_adapters`:
     "repetition_penalty": 1.15,
     "scale": 2.0,
     "max_tokens": 512,
-    "worldview": "russell_worldview.txt"
+    "worldview": "russell_worldview.txt",
+    "use_structural_rag": true,
+    "logit_bias": {
+        ";": 1.0,
+        "—": 1.5
+    }
 }
 ```
+
+### Per-adapter overrides
+
+Most generation-wide settings can be overridden per-adapter. Omit the field to inherit the global `generation.*` value.
+
+| Field | Type | Purpose |
+|---|---|---|
+| `expand_for_texture` | bool | Pre-expand via critic before RTT |
+| `perspective` | string | Output POV (`preserve`, `first_person_singular`, …) |
+| `verify_entailment` | bool | Run NLI semantic fidelity check |
+| `merge_paragraphs` | int | Merge N paragraphs before LoRA |
+| `use_structural_rag` | bool | Pull rhythm patterns from corpus |
+| `logit_bias` | object | Additive bias per character/string (see below) |
+
+### `logit_bias` — per-character logit bias
+
+Map of character/string → float. At every sampling step the value is added to that token's logit. Positive values encourage the token; negative values suppress. Typical range: −5.0 to +5.0.
+
+```json
+"logit_bias": {
+    ";": 1.0,
+    "—": 1.5,
+    "…": -2.0
+}
+```
+
+Resolution handles BPE quirks: each key is tokenized as both the bare string and with a leading space; if either variant is a single token, both token IDs get the bias. Keys that split into >1 token are skipped with a warning (biasing partial multi-token sequences produces artifacts).
+
+Use this to nudge characteristic author punctuation (em-dash, semicolon) without fighting `repetition_penalty`. The two work independently: rep penalty divides logits, logit_bias adds.
 
 ### Tuning Tips
 
 - **Style too weak**: Increase `scale` (try 3.0-4.0)
 - **Incoherent output**: Decrease `temperature` (try 0.4-0.5)
 - **Repeating phrases**: Increase `repetition_penalty` (try 1.2-1.3)
+- **Punctuation flattened** (no em-dashes/semicolons after first use): Add a positive `logit_bias` for those characters instead of raising repetition_penalty
 - **Output too short**: This is by design (LoRA trained on ~1.21x ratio).
   Enable `expand_for_texture: true` to pre-expand content before LoRA.
 - **Mechanical/robotic**: Enable `apply_input_perturbation: true` to match training distribution

--- a/src/config.py
+++ b/src/config.py
@@ -89,6 +89,11 @@ class ModelConfig:
     verify_entailment: Optional[bool] = None
     merge_paragraphs: Optional[int] = None
     use_structural_rag: Optional[bool] = None
+    # Additive logit bias per character/string. Keys are strings (e.g. ";",
+    # "—"), values are floats added to that token's logit at every sampling
+    # step. Positive values encourage the token; negative values suppress.
+    # Typical range: -5.0 to +5.0.
+    logit_bias: Dict[str, float] = field(default_factory=dict)
 
     # LoRA-only
     scale: float = 1.0
@@ -252,6 +257,7 @@ _KNOWN_MODEL_FIELDS = {
     "verify_entailment",
     "merge_paragraphs",
     "use_structural_rag",
+    "logit_bias",
     "author",
 }
 
@@ -292,6 +298,7 @@ def _parse_model_config(data: Dict) -> ModelConfig:
         verify_entailment=data.get("verify_entailment"),
         merge_paragraphs=data.get("merge_paragraphs"),
         use_structural_rag=data.get("use_structural_rag"),
+        logit_bias=data.get("logit_bias", {}),
         author=data.get("author", ""),
     )
 

--- a/src/generation/base_generator.py
+++ b/src/generation/base_generator.py
@@ -6,8 +6,8 @@ shared between MLX and PyTorch backends.
 
 import re
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
-from typing import Optional, List
+from dataclasses import dataclass, field
+from typing import Dict, Optional, List
 
 from ..utils.logging import get_logger
 
@@ -85,6 +85,7 @@ class GenerationConfig:
     repetition_penalty: float = 1.15
     scale: float = 1.0  # LoRA adapter scale
     skip_cleaning: bool = False  # If True, return raw output without cleaning
+    logit_bias: Dict[str, float] = field(default_factory=dict)
 
     @classmethod
     def from_config(cls, adapter_path: Optional[str] = None) -> "GenerationConfig":
@@ -107,6 +108,7 @@ class GenerationConfig:
                 min_p=adapter_config.min_p,
                 repetition_penalty=adapter_config.repetition_penalty,
                 scale=adapter_config.scale,
+                logit_bias=dict(adapter_config.logit_bias),
             )
         except Exception as e:
             logger.warning(f"Could not load config, using defaults: {e}")
@@ -126,6 +128,7 @@ class GenerationConfig:
             min_p=fused_config.min_p,
             repetition_penalty=fused_config.repetition_penalty,
             scale=1.0,
+            logit_bias=dict(fused_config.logit_bias),
         )
 
 

--- a/src/generation/lora_generator.py
+++ b/src/generation/lora_generator.py
@@ -14,7 +14,7 @@ import os
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional, List
+from typing import Dict, Optional, List
 
 from ..utils.logging import get_logger
 from ..utils.prompts import format_prompt
@@ -160,6 +160,10 @@ class LoRAStyleGenerator(BaseStyleGenerator):
         # Lazy load model
         self._model = None
         self._tokenizer = None
+
+        # Built lazily on first generate() call: sentinel None = not-yet-built,
+        # callable = the processor, False = empty bias map (nothing to apply).
+        self._logit_bias_processor = None
 
         # Load metadata from first adapter if available
         if self.adapters:
@@ -382,6 +386,70 @@ class LoRAStyleGenerator(BaseStyleGenerator):
         except Exception as e:
             logger.warning(f"Could not apply LoRA scale: {e}")
 
+    def _build_logit_bias_processor(self):
+        """Build a logits processor that adds per-token bias every step.
+
+        Reads self.config.logit_bias (Dict[str, float]) and resolves each key
+        to token IDs via the tokenizer. Handles BPE quirks by trying both the
+        bare string and a leading-space variant — most subword tokenizers
+        encode ";" and " ;" to different token IDs and the model may emit
+        either. Strings that encode to more than one token are skipped with
+        a warning (biasing a partial multi-token sequence causes artifacts).
+
+        Returns a callable (tokens, logits) -> logits, or None if the bias
+        map is empty or no keys resolved cleanly.
+        """
+        import mlx.core as mx
+
+        bias_map = self.config.logit_bias
+        if not bias_map:
+            return None
+
+        resolved: Dict[int, float] = {}
+        for s, bias in bias_map.items():
+            if not isinstance(bias, (int, float)):
+                logger.warning(f"logit_bias: non-numeric value for {s!r}, skipped")
+                continue
+            added = False
+            for variant in (s, " " + s):
+                try:
+                    ids = self._tokenizer.encode(variant, add_special_tokens=False)
+                except Exception as e:
+                    logger.warning(f"logit_bias: encode failed for {variant!r}: {e}")
+                    continue
+                if len(ids) == 1:
+                    resolved[ids[0]] = float(bias)
+                    added = True
+            if not added:
+                logger.warning(
+                    f"logit_bias: {s!r} did not resolve to any single-token "
+                    f"variant (bare or leading-space) — skipped"
+                )
+
+        if not resolved:
+            return None
+
+        vocab_size = self._model.args.vocab_size if hasattr(self._model, "args") else None
+        if vocab_size is None:
+            max_id = max(resolved.keys())
+            vocab_size = max_id + 1
+
+        import numpy as np
+        bias_np = np.zeros(vocab_size, dtype=np.float32)
+        for tok_id, bias in resolved.items():
+            bias_np[tok_id] = bias
+        bias_vec = mx.array(bias_np)
+
+        logger.info(
+            f"logit_bias: applied to {len(resolved)} token IDs "
+            f"({', '.join(f'{s!r}={v:+.2f}' for s, v in bias_map.items())})"
+        )
+
+        def processor(tokens, logits):
+            return logits + bias_vec
+
+        return processor
+
     def generate(
         self,
         content: str,
@@ -508,6 +576,16 @@ class LoRAStyleGenerator(BaseStyleGenerator):
             context_size=50,
         )
 
+        # Build logit-bias processor on first call, reuse on subsequent calls.
+        # Sentinel None = not-yet-built; False = built-but-empty (no bias map).
+        if self._logit_bias_processor is None:
+            built = self._build_logit_bias_processor()
+            self._logit_bias_processor = built if built is not None else False
+
+        logits_processors = [rep_penalty]
+        if self._logit_bias_processor:
+            logits_processors.append(self._logit_bias_processor)
+
         # Use provided max_tokens, or auto-calculated limit, or config default
         # Prefer tighter auto-calculated limit to prevent repetition
         if max_tokens:
@@ -528,7 +606,7 @@ class LoRAStyleGenerator(BaseStyleGenerator):
             prompt=prompt,
             max_tokens=tokens_limit,
             sampler=sampler,
-            logits_processors=[rep_penalty],
+            logits_processors=logits_processors,
         )
 
         response = response.strip()


### PR DESCRIPTION
Adds optional `logit_bias` map (character/string → float) to ModelConfig, plumbed through GenerationConfig into the MLX generator as an additive logits processor. Each key is resolved to token IDs via the tokenizer, trying both bare and leading-space BPE variants; keys that split into more than one token are skipped with a warning. The bias vector is built once per generator and added to logits every sampling step, stacking cleanly with the existing repetition penalty.

Motivation: repetition_penalty is blunt and suppresses characteristic author punctuation (em-dashes, semicolons) after first use. Per-character bias lets an adapter nudge these tokens without fighting rep penalty.